### PR TITLE
feat(ssg): add static HTML generation via --static flag and 'use static' directive

### DIFF
--- a/bin/aplos
+++ b/bin/aplos
@@ -27,9 +27,14 @@ program
   .command("build")
   .description("Build assets")
   .option(
-    "--mode",
+    "--mode <mode>",
     "Providing the mode configuration option tells webpack to use its built-in optimizations accordingly",
     process.env.NODE_ENV || "development"
+  )
+  .option(
+    "--static",
+    "Pre-render each static route to HTML (SSG). Dynamic routes fall back to SPA.",
+    false
   )
   .action(build);
 

--- a/rspack.ssr.config.js
+++ b/rspack.ssr.config.js
@@ -1,0 +1,124 @@
+import path from "path";
+import { CssExtractRspackPlugin } from "@rspack/core";
+import { fileURLToPath, pathToFileURL } from "url";
+import fs from "fs";
+import { merge } from "webpack-merge";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const projectDirectory = process.cwd();
+
+// Inherit project aliases/loaders from the client config (e.g. `@docs` alias,
+// `.md` loader). A dedicated `rspack.ssr.config.js` in the project can override.
+let userConfig = {};
+const userClientConfigPath = path.resolve(projectDirectory, "rspack.config.js");
+if (fs.existsSync(userClientConfigPath)) {
+  try {
+    const userModule = await import(pathToFileURL(userClientConfigPath).href);
+    userConfig = userModule.default || userModule;
+  } catch (error) {
+    console.error("Error loading project rspack.config.js for SSR:", error.message);
+  }
+}
+const userSSRConfigPath = path.resolve(projectDirectory, "rspack.ssr.config.js");
+if (fs.existsSync(userSSRConfigPath)) {
+  try {
+    const userModule = await import(pathToFileURL(userSSRConfigPath).href);
+    userConfig = merge(userConfig, userModule.default || userModule);
+  } catch (error) {
+    console.error("Error loading project rspack.ssr.config.js:", error.message);
+  }
+}
+
+const frameworkConfig = {
+  mode: "production",
+  target: "node",
+  devtool: false,
+  stats: "errors-warnings",
+  infrastructureLogging: { level: "error" },
+  output: {
+    path: path.resolve(projectDirectory, "./.aplos/cache"),
+    filename: "ssr-bundle.cjs",
+    library: { type: "commonjs2" },
+    clean: false,
+  },
+  externals: {
+    react: "commonjs react",
+    "react-dom": "commonjs react-dom",
+    "react-dom/server": "commonjs react-dom/server",
+    "react-router": "commonjs react-router",
+    "react-router-dom": "commonjs react-router-dom",
+  },
+  optimization: {
+    minimize: false,
+    splitChunks: false,
+    usedExports: false,
+    sideEffects: false,
+  },
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|jsx|tsx)$/,
+        exclude: /node_modules\/(?!aplos)|bower_components|\.aplos[\\/]cache/,
+        use: [
+          {
+            loader: "builtin:swc-loader",
+            options: {
+              jsc: {
+                parser: { syntax: "typescript", tsx: true },
+                transform: {
+                  react: { runtime: "automatic", refresh: false },
+                },
+              },
+              env: { targets: { node: "18" } },
+            },
+          },
+        ],
+      },
+      {
+        test: /\.css$/,
+        use: [CssExtractRspackPlugin.loader, "css-loader", "postcss-loader"],
+      },
+      {
+        test: /\.md$/,
+        type: "asset/source",
+      },
+    ],
+  },
+  plugins: [
+    new CssExtractRspackPlugin({
+      filename: "ssr-[name].css",
+      chunkFilename: "ssr-[id].css",
+    }),
+  ],
+  resolveLoader: {
+    modules: [
+      path.resolve(projectDirectory, "node_modules"),
+      path.resolve(__dirname, "node_modules"),
+      "node_modules",
+    ],
+  },
+  resolve: {
+    alias: {
+      "react": path.resolve(projectDirectory, "node_modules/react"),
+      "react-dom": path.resolve(projectDirectory, "node_modules/react-dom"),
+      "react-router-dom": path.resolve(projectDirectory, "node_modules/react-router-dom"),
+      "react-router": path.resolve(projectDirectory, "node_modules/react-router"),
+      "aplos/config": path.resolve(__dirname, "src/config.js"),
+      "aplos/navigation": path.resolve(__dirname, "src/components/navigation.jsx"),
+      "aplos/head": path.resolve(__dirname, "src/components/head.jsx"),
+      "@": projectDirectory + "/src",
+      "~": projectDirectory + "/src",
+      "@aplos_config": projectDirectory + "/.aplos/cache/config.js",
+      "@aplos_routes": projectDirectory + "/.aplos/cache/routes.js",
+      "@aplos_pages": projectDirectory + "/.aplos/cache/pages.js",
+      "@aplos_head": projectDirectory + "/.aplos/cache/head.js",
+      "aplos/internal/passthrough-layout": path.resolve(__dirname, "src/runtime/passthrough-layout.jsx"),
+      "aplos/internal/default-not-found": path.resolve(__dirname, "src/runtime/default-not-found.jsx"),
+    },
+    extensions: [".ts", ".tsx", ".js", ".jsx"],
+  },
+};
+
+export default merge(frameworkConfig, userConfig);

--- a/src/build/router.js
+++ b/src/build/router.js
@@ -71,13 +71,17 @@ export async function buildRouter(aplos) {
         path = path.replace(/\[\.\.\..*?]/g, '*');
         path = path.replace(/\[(.*?)]/g, ':$1');
 
+        const absolutePageFile = `${pageDirectory}${file.replace('~', '')}`;
+        const staticDirective = hasUseStaticDirective(absolutePageFile);
+
         let existingPage = pages.find(p => p.path === path);
         if (!existingPage) {
             const config = {
                 "path": path,
                 "component": capitalizeName,
                 "file": file.replaceAll('//', '/'),
-                "requirement": {}
+                "requirement": {},
+                "static": staticDirective
             };
 
             routes.push(config);
@@ -214,6 +218,7 @@ function serializeRouteTree(nodes, indent = '') {
         const parts = [];
         if (node.component) parts.push(`${inner}element: ${node.component}`);
         if (node.path !== undefined) parts.push(`${inner}path: ${JSON.stringify(node.path)}`);
+        if (node.static === true) parts.push(`${inner}static: true`);
         if (node.children) {
             parts.push(`${inner}children: ${serializeRouteTree(node.children, inner)}`);
         }
@@ -238,6 +243,35 @@ function generateHeadFile(head, reactStrictMode) {
     lines.push(`export default ${JSON.stringify(headObj, null, 2)};`);
     lines.push(`export const reactStrictMode = ${!!reactStrictMode};`);
     return lines.join('\n') + '\n';
+}
+
+/**
+ * Detect a leading `'use static'` / `"use static"` directive in a page file.
+ * Scans the first non-empty, non-comment lines before any code/import.
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function hasUseStaticDirective(filePath) {
+    try {
+        const source = fs.readFileSync(filePath, 'utf-8');
+        const lines = source.split('\n');
+        for (const rawLine of lines) {
+            const line = rawLine.trim();
+            if (line === '') {
+                continue;
+            }
+            if (line.startsWith('//') || line.startsWith('/*') || line.startsWith('*')) {
+                continue;
+            }
+            if (line === `'use static';` || line === `"use static";` || line === `'use static'` || line === `"use static"`) {
+                return true;
+            }
+            return false;
+        }
+    } catch (error) {
+        return false;
+    }
+    return false;
 }
 
 /**
@@ -367,7 +401,11 @@ function buildNestedRoutes(pages, layoutTree) {
         // Add pages for this level
         const pagesAtLevel = routesByPath.get(currentPath) || [];
         pagesAtLevel.forEach(page => {
-            nodes.push({ path: page.path, component: page.component });
+            const node = { path: page.path, component: page.component };
+            if (page.static) {
+                node.static = true;
+            }
+            nodes.push(node);
         });
 
         // Add nested layouts

--- a/src/build/ssg.js
+++ b/src/build/ssg.js
@@ -46,7 +46,7 @@ async function buildSSRBundle(projectDirectory, frameworkDirectory, mode) {
     });
 }
 
-export default async function ssg({ mode }) {
+export default async function ssg({ mode, forceAll = false } = {}) {
     const projectDirectory = process.cwd();
     const frameworkDirectory = path.resolve(__dirname, '../..');
     const distDir = path.join(projectDirectory, 'public', 'dist');
@@ -55,6 +55,18 @@ export default async function ssg({ mode }) {
     const indexHtmlPath = path.join(distDir, 'index.html');
     if (!fs.existsSync(indexHtmlPath)) {
         throw new Error(`SSG: ${indexHtmlPath} not found — run the client build first.`);
+    }
+
+    // Skip the expensive SSR bundle build if no page opted in and --static wasn't passed.
+    if (!forceAll) {
+        const routesPath = path.join(cacheDir, 'routes.js');
+        if (!fs.existsSync(routesPath)) {
+            return;
+        }
+        const source = fs.readFileSync(routesPath, 'utf-8');
+        if (!/static:\s*true/.test(source)) {
+            return;
+        }
     }
 
     console.log('\n  Building SSR bundle...');
@@ -72,9 +84,8 @@ export default async function ssg({ mode }) {
         throw new Error('SSG: SSR bundle must export render(url) and getStaticRoutes().');
     }
 
-    const staticRoutes = getStaticRoutes();
+    const staticRoutes = getStaticRoutes({ forceAll });
     if (staticRoutes.length === 0) {
-        console.log('  No static routes to pre-render.');
         return;
     }
 

--- a/src/build/ssg.js
+++ b/src/build/ssg.js
@@ -1,0 +1,103 @@
+import fs from 'fs';
+import path from 'path';
+import { spawn } from 'child_process';
+import { pathToFileURL, fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const SSR_ENTRY = path.resolve(__dirname, '../runtime/ssr-entry.jsx');
+const SSR_BUNDLE_NAME = 'ssr-bundle.cjs';
+
+function outputHtmlPath(distDir, routePath) {
+    if (routePath === '/' || routePath === '') {
+        return path.join(distDir, 'index.html');
+    }
+    const trimmed = routePath.replace(/^\/+/, '').replace(/\/+$/, '');
+    return path.join(distDir, `${trimmed}.html`);
+}
+
+async function buildSSRBundle(projectDirectory, frameworkDirectory, mode) {
+    const ssrConfigPath = path.resolve(frameworkDirectory, 'rspack.ssr.config.js');
+    const rspackBin = path.join(projectDirectory, 'node_modules', '.bin', 'rspack');
+
+    return new Promise((resolve, reject) => {
+        const child = spawn(rspackBin, [
+            '--mode=' + mode,
+            '--config', ssrConfigPath,
+            '--entry', SSR_ENTRY,
+        ], {
+            env: { ...process.env, APLOS_SSR: '1' },
+        });
+
+        let stderr = '';
+        child.stdout.on('data', (d) => process.stdout.write(d));
+        child.stderr.on('data', (d) => {
+            stderr += d.toString();
+            process.stderr.write(d);
+        });
+        child.on('close', (code) => {
+            if (code !== 0) {
+                reject(new Error(`SSR bundle failed (exit ${code}): ${stderr}`));
+            } else {
+                resolve();
+            }
+        });
+    });
+}
+
+export default async function ssg({ mode }) {
+    const projectDirectory = process.cwd();
+    const frameworkDirectory = path.resolve(__dirname, '../..');
+    const distDir = path.join(projectDirectory, 'public', 'dist');
+    const cacheDir = path.join(projectDirectory, '.aplos', 'cache');
+
+    const indexHtmlPath = path.join(distDir, 'index.html');
+    if (!fs.existsSync(indexHtmlPath)) {
+        throw new Error(`SSG: ${indexHtmlPath} not found — run the client build first.`);
+    }
+
+    console.log('\n  Building SSR bundle...');
+    await buildSSRBundle(projectDirectory, frameworkDirectory, mode || 'production');
+
+    const ssrBundlePath = path.join(cacheDir, SSR_BUNDLE_NAME);
+    if (!fs.existsSync(ssrBundlePath)) {
+        throw new Error(`SSG: SSR bundle not produced at ${ssrBundlePath}.`);
+    }
+
+    const ssrMod = await import(pathToFileURL(ssrBundlePath).href);
+    const render = ssrMod.render || ssrMod.default?.render;
+    const getStaticRoutes = ssrMod.getStaticRoutes || ssrMod.default?.getStaticRoutes;
+    if (typeof render !== 'function' || typeof getStaticRoutes !== 'function') {
+        throw new Error('SSG: SSR bundle must export render(url) and getStaticRoutes().');
+    }
+
+    const staticRoutes = getStaticRoutes();
+    if (staticRoutes.length === 0) {
+        console.log('  No static routes to pre-render.');
+        return;
+    }
+
+    const template = fs.readFileSync(indexHtmlPath, 'utf-8');
+    const rootMarker = /<div id="root">\s*<\/div>/;
+    if (!rootMarker.test(template)) {
+        throw new Error('SSG: could not find <div id="root"></div> in index.html template.');
+    }
+
+    console.log(`  Pre-rendering ${staticRoutes.length} route(s)...`);
+    let rendered = 0;
+    for (const route of staticRoutes) {
+        try {
+            const html = render(route);
+            const page = template.replace(rootMarker, `<div id="root">${html}</div>`);
+            const outPath = outputHtmlPath(distDir, route);
+            fs.mkdirSync(path.dirname(outPath), { recursive: true });
+            fs.writeFileSync(outPath, page, 'utf-8');
+            console.log(`    ✓ ${route} → ${path.relative(projectDirectory, outPath)}`);
+            rendered++;
+        } catch (err) {
+            console.error(`    ✗ ${route}: ${err.message}`);
+        }
+    }
+    console.log(`  Pre-rendered ${rendered}/${staticRoutes.length} route(s).`);
+}

--- a/src/command/build.js
+++ b/src/command/build.js
@@ -95,13 +95,11 @@ export default async (options) => {
             showBundleAnalysis(projectDirectory);
         }
 
-        if (options.static) {
-            try {
-                await ssg({ mode: options.mode });
-            } catch (err) {
-                console.error(`SSG failed: ${err.message}`);
-                process.exitCode = 1;
-            }
+        try {
+            await ssg({ mode: options.mode, forceAll: options.static });
+        } catch (err) {
+            console.error(`SSG failed: ${err.message}`);
+            process.exitCode = 1;
         }
     });
 };

--- a/src/command/build.js
+++ b/src/command/build.js
@@ -1,6 +1,7 @@
 import {spawn} from "child_process";
 import {buildRouter}  from "../build/router.js";
 import get_config from '../build/config.js';
+import ssg from '../build/ssg.js';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
@@ -81,16 +82,25 @@ export default async (options) => {
         console.log(`stderr: ${data.toString()}`);
     });
 
-    rspack.on('close', (code) => {
+    rspack.on('close', async (code) => {
         if (code !== 0) {
             console.log(`error: Process exited with code ${code}`);
-        } else {
-            const totalTime = Math.round(performance.now() - buildStart);
-            console.log(`\n  Built in ${totalTime}ms`);
+            return;
+        }
 
-            // Show build analysis in production
-            if (options.mode === 'production' || process.env.NODE_ENV === 'production') {
-                showBundleAnalysis(projectDirectory);
+        const totalTime = Math.round(performance.now() - buildStart);
+        console.log(`\n  Built in ${totalTime}ms`);
+
+        if (options.mode === 'production' || process.env.NODE_ENV === 'production') {
+            showBundleAnalysis(projectDirectory);
+        }
+
+        if (options.static) {
+            try {
+                await ssg({ mode: options.mode });
+            } catch (err) {
+                console.error(`SSG failed: ${err.message}`);
+                process.exitCode = 1;
             }
         }
     });

--- a/src/runtime/app-ssr.jsx
+++ b/src/runtime/app-ssr.jsx
@@ -1,0 +1,42 @@
+import React, { createElement } from 'react';
+import { StaticRouter, Routes, Route } from 'react-router';
+
+import { routeTree } from '@aplos_routes';
+import { CustomError, NoMatch } from '@aplos_pages';
+import { reactStrictMode } from '@aplos_head';
+
+import ErrorBoundary from './ErrorBoundary.jsx';
+import DefaultErrorPage from './DefaultErrorPage.jsx';
+
+function renderRoutes(nodes) {
+    return nodes.map((node, i) => {
+        if (node.children) {
+            return (
+                <Route key={i} element={createElement(node.element)}>
+                    {renderRoutes(node.children)}
+                </Route>
+            );
+        }
+        return <Route key={i} path={node.path} element={createElement(node.element)} />;
+    });
+}
+
+export default function AppSSR({ url }) {
+    const ErrorComponent = CustomError || DefaultErrorPage;
+    const tree = (
+        <ErrorBoundary errorComponent={ErrorComponent}>
+            <StaticRouter location={url}>
+                <Routes>
+                    {renderRoutes(routeTree)}
+                    <Route path="*" element={createElement(NoMatch)} />
+                </Routes>
+            </StaticRouter>
+        </ErrorBoundary>
+    );
+
+    if (reactStrictMode) {
+        const { StrictMode } = React;
+        return <StrictMode>{tree}</StrictMode>;
+    }
+    return tree;
+}

--- a/src/runtime/ssr-entry.jsx
+++ b/src/runtime/ssr-entry.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { renderToString } from 'react-dom/server';
+import AppSSR from './app-ssr.jsx';
+import { routeTree } from '@aplos_routes';
+
+export function render(url) {
+    return renderToString(<AppSSR url={url} />);
+}
+
+function isStaticPath(p) {
+    if (!p) {
+        return false;
+    }
+    if (p.includes(':')) {
+        return false;
+    }
+    if (p.includes('*')) {
+        return false;
+    }
+    return true;
+}
+
+function walk(nodes, acc) {
+    for (const node of nodes) {
+        if (node.path !== undefined && isStaticPath(node.path)) {
+            acc.push(node.path);
+        }
+        if (node.children) {
+            walk(node.children, acc);
+        }
+    }
+}
+
+export function getStaticRoutes() {
+    const acc = [];
+    walk(routeTree, acc);
+    return Array.from(new Set(acc));
+}
+
+export default { render, getStaticRoutes };

--- a/src/runtime/ssr-entry.jsx
+++ b/src/runtime/ssr-entry.jsx
@@ -20,20 +20,22 @@ function isStaticPath(p) {
     return true;
 }
 
-function walk(nodes, acc) {
+function walk(nodes, acc, forceAll) {
     for (const node of nodes) {
         if (node.path !== undefined && isStaticPath(node.path)) {
-            acc.push(node.path);
+            if (forceAll || node.static === true) {
+                acc.push(node.path);
+            }
         }
         if (node.children) {
-            walk(node.children, acc);
+            walk(node.children, acc, forceAll);
         }
     }
 }
 
-export function getStaticRoutes() {
+export function getStaticRoutes({ forceAll = false } = {}) {
     const acc = [];
-    walk(routeTree, acc);
+    walk(routeTree, acc, forceAll);
     return Array.from(new Set(acc));
 }
 


### PR DESCRIPTION
## Summary

- Adds \`aplos build --static\` which pre-renders every statifiable route to HTML at build time via \`react-dom/server\` + \`StaticRouter\`.
- Adds a per-page \`'use static'\` directive: without the \`--static\` flag, only pages that opt in via the directive are pre-rendered. With \`--static\`, the directive is ignored and every static route is pre-rendered.
- Catch-all / dynamic routes (\`*\`, \`:param\`) are skipped for now (a \`getStaticPaths\` API is planned as a follow-up).
- SSR build reuses the project's \`rspack.config.js\` (aliases, loaders like \`.md\` → \`asset/source\`) and lets a project override specifics via an optional \`rspack.ssr.config.js\`.

## Behavior

| Mode | Page without directive | Page with \`'use static'\` |
|------|------------------------|--------------------------|
| \`aplos build\`          | SPA (empty \`#root\`)    | Pre-rendered HTML        |
| \`aplos build --static\` | Pre-rendered HTML      | Pre-rendered HTML        |

## Architecture

- \`src/runtime/app-ssr.jsx\` — React tree wrapped in \`StaticRouter\`.
- \`src/runtime/ssr-entry.jsx\` — exposes \`render(url)\` and \`getStaticRoutes({ forceAll })\`.
- \`rspack.ssr.config.js\` — Rspack config targeting \`node\`, externalizes React/react-router, inherits project client config.
- \`src/build/ssg.js\` — orchestrator: builds the SSR bundle, loads it, walks routes, writes \`<route>.html\` into \`public/dist/\`.
- \`src/build/router.js\` — scans the first non-comment line of each page for \`'use static'\` and flags the route accordingly.
- \`src/command/build.js\` — always invokes \`ssg()\` after the client build; skips the SSR bundle entirely when neither \`--static\` nor any \`'use static'\` directive is present.

## Test plan

- [x] \`cd website && NODE_ENV=production bun run build\` — no pre-rendering (no directive, no flag), \`#root\` is empty.
- [x] Add \`'use static';\` to \`website/src/pages/index.tsx\`, rebuild — \`/\` is pre-rendered, \`#root\` contains the hero markup.
- [x] \`NODE_ENV=production aplos build --static\` — every static route is pre-rendered regardless of the directive.
