### PR TITLE
perf(build): make React Compiler opt-in via reactCompiler config flag

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -23,16 +23,18 @@ if (fs.existsSync(userTemplate)) {
   console.log("Using custom HTML template from public/index.html");
 }
 
-// Load configuration to get head meta tags
+// Load project configuration
 let headConfig = { meta: [], link: [], script: [] };
+let reactCompilerEnabled = false;
 const configPath = path.join(projectDirectory, 'aplos.config.js');
 if (fs.existsSync(configPath)) {
   try {
     const configModule = await import(pathToFileURL(configPath).href);
     const config = configModule.default || configModule;
     headConfig = config.head || headConfig;
+    reactCompilerEnabled = config.reactCompiler === true;
   } catch (error) {
-    console.error('Error loading configuration for head tags:', error);
+    console.error('Error loading configuration:', error);
   }
 }
 
@@ -215,14 +217,16 @@ const frameworkConfig = {
         exclude: /node_modules\/(?!aplos)|bower_components|\.aplos[\\/]cache/,
         use: [
           // Loaders run bottom-up: SWC transpiles first (TS/JSX → JS), then Babel
-          // receives already-transpiled JS and only applies React Compiler
-          // (and react-refresh/babel in dev).
-          {
+          // applies React Compiler (opt-in) and react-refresh/babel (dev).
+          // Babel is skipped entirely when neither is needed — SWC alone is
+          // ~7x faster. Enable React Compiler via `reactCompiler: true` in
+          // aplos.config.js when auto-memoization benefits justify the cost.
+          (isDevelopment || reactCompilerEnabled) && {
             loader: "babel-loader",
             options: {
               presets: [],
               plugins: [
-                ["babel-plugin-react-compiler", {}],
+                reactCompilerEnabled && ["babel-plugin-react-compiler", {}],
                 isDevelopment && "react-refresh/babel",
               ].filter(Boolean),
             },
@@ -247,7 +251,7 @@ const frameworkConfig = {
               },
             },
           },
-        ],
+        ].filter(Boolean),
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
## Summary
- React Compiler was running via Babel on every file in every build (dev + prod), adding a second transpilation pass on top of SWC.
- Made it opt-in via `reactCompiler: true` in `aplos.config.js`. Default is off.
- When disabled, the Babel loader is skipped entirely in prod — only SWC runs.

## Impact measured on a real project (Lugha, 108 TS/TSX files, 1943 modules)
| Mode | Build time |
|---|---|
| Before (compiler always on) | ~32s |
| After, default (compiler off) | **~4.5s** (~7x faster) |
| After, `reactCompiler: true` | ~10.4s |

## Why opt-in
React Compiler provides auto-memoization but has no Rust/SWC port yet, so it forces a Babel pass that dominates build time. Next.js, Vite, Nuxt all keep it opt-in for the same reason. Users who want auto-memoization can enable it per-project once they've validated the runtime benefit (e.g. via React DevTools Profiler or react-scan).

## Usage
```js
// aplos.config.js
module.exports = {
  reactCompiler: true, // opt-in, defaults to false
}
```