### PR TITLE
feat(ssg): static paths config + auto-discovered docs site

### DIFF
--- a/src/build/router.js
+++ b/src/build/router.js
@@ -64,7 +64,7 @@ export async function buildRouter(aplos) {
         }
 
         let found = routes.find(element => element.source === path);
-        if (found) {
+        if (found && found.destination) {
             path = found.destination;
         }
 
@@ -89,14 +89,65 @@ export async function buildRouter(aplos) {
         }
     });
 
+    // Expand `paths` declared in route entries into concrete static pages that
+    // share the component of their matching catch-all. Lets the SSG pre-render
+    // each URL without asking the user to split the catch-all into many files.
+    const configuredRoutes = aplos.routes || [];
+    for (const entry of configuredRoutes) {
+        if (!entry || !entry.paths || !entry.source) {
+            continue;
+        }
+        const catchAllPath = entry.source.replace(/\[\.\.\..*?]/g, '*').replace(/\[(.*?)]/g, ':$1');
+        const catchAll = pages.find(p => p.path === catchAllPath);
+        if (!catchAll) {
+            console.warn(`Route config: no page matches source "${entry.source}" — skipping paths expansion.`);
+            continue;
+        }
+        let paths = entry.paths;
+        if (typeof paths === 'function') {
+            try {
+                paths = paths();
+            } catch (error) {
+                console.error(`Route config: paths() threw for source "${entry.source}":`, error.message);
+                continue;
+            }
+        }
+        if (!Array.isArray(paths)) {
+            console.warn(`Route config: paths for "${entry.source}" must be an array or a function returning one.`);
+            continue;
+        }
+        for (const concretePath of paths) {
+            if (typeof concretePath !== 'string' || !concretePath.startsWith('/')) {
+                continue;
+            }
+            if (pages.find(p => p.path === concretePath)) {
+                continue;
+            }
+            pages.push({
+                path: concretePath,
+                component: catchAll.component,
+                file: catchAll.file,
+                requirement: {},
+                static: true,
+            });
+        }
+    }
+
     // Detect _app, _404, _error files
     const appFile = findSpecialFile(pageDirectory, '_app', appExtensions);
     const notFoundFile = findSpecialFile(pageDirectory, '_404', appExtensions);
     const errorFile = findSpecialFile(pageDirectory, '_error', appExtensions);
 
-    // Generate pages.js (re-exports for all pages + special files)
+    // Generate pages.js (re-exports for all pages + special files). Pages
+    // expanded from `routes[].paths` reuse the same component as their
+    // catch-all parent, so we dedupe exports by component name here.
     const pagesExports = [];
+    const exportedComponents = new Set();
     pages.forEach(page => {
+        if (exportedComponents.has(page.component)) {
+            return;
+        }
+        exportedComponents.add(page.component);
         const componentFileName = page.file.replace('~', '');
         pagesExports.push(`export { default as ${page.component} } from "${projectDirectory}/src/pages${componentFileName}";`);
     });

--- a/website/aplos.config.js
+++ b/website/aplos.config.js
@@ -1,8 +1,39 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+function walkMdFiles(dir, prefix = '') {
+  const out = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const abs = path.join(dir, entry.name);
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      out.push(...walkMdFiles(abs, rel));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      out.push(rel.replace(/\.md$/, '').replace(/\/?index$/, ''));
+    }
+  }
+  return out;
+}
+
 module.exports = {
   reactStrictMode: true,
   server: {
     port: 3001,
   },
+  routes: [
+    {
+      source: '/documentation/[...path]',
+      paths: () => {
+        const docsDir = path.resolve(__dirname, '../documentation');
+        if (!fs.existsSync(docsDir)) {
+          return [];
+        }
+        return walkMdFiles(docsDir).map((slug) =>
+          slug === '' ? '/documentation' : `/documentation/${slug}`
+        );
+      },
+    },
+  ],
   head: {
     defaultTitle: 'Aplos - The Fast React Framework',
     titleTemplate: '%s | Aplos',

--- a/website/rspack.config.js
+++ b/website/rspack.config.js
@@ -1,0 +1,21 @@
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export default {
+  resolve: {
+    alias: {
+      '@docs': path.resolve(__dirname, '../documentation'),
+    },
+  },
+  module: {
+    rules: [
+      {
+        test: /\.md$/,
+        type: 'asset/source',
+      },
+    ],
+  },
+};

--- a/website/src/components/DocSidebar.tsx
+++ b/website/src/components/DocSidebar.tsx
@@ -1,45 +1,46 @@
 import { useState } from 'react';
 import { NavLink } from 'aplos/navigation';
+import { getAllDocs, docToUrl, humanize } from '@/lib/docs';
 import '@/styles/components/sidebar.css';
 
-const sections = [
-  {
-    title: 'Getting Started',
-    links: [
-      { to: '/documentation', label: 'Overview' },
-      { to: '/documentation/installation', label: 'Installation' },
-      { to: '/documentation/quick-start', label: 'Quick Start' },
-    ],
-  },
-  {
-    title: 'Routing',
-    links: [
-      { to: '/documentation/routing/file-based', label: 'File-based Routing' },
-      { to: '/documentation/routing/layouts', label: 'Layouts' },
-      { to: '/documentation/routing/dynamic-routes', label: 'Dynamic Routes' },
-    ],
-  },
-  {
-    title: 'Configuration',
-    links: [
-      { to: '/documentation/configuration', label: 'Overview' },
-      { to: '/documentation/configuration/rspack', label: 'Custom Rspack Config' },
-      { to: '/documentation/configuration/runtime', label: 'Runtime Configuration' },
-    ],
-  },
-  {
-    title: 'CLI',
-    links: [
-      { to: '/documentation/cli', label: 'Commands' },
-    ],
-  },
-  {
-    title: 'API',
-    links: [
-      { to: '/documentation/api', label: 'Components & Hooks' },
-    ],
-  },
-];
+interface Link {
+  to: string;
+  label: string;
+}
+
+interface Section {
+  title: string;
+  links: Link[];
+}
+
+function buildSections(): Section[] {
+  const rootLinks: Link[] = [];
+  const sectionsByFolder = new Map<string, Link[]>();
+
+  for (const doc of getAllDocs()) {
+    const link = { to: docToUrl(doc.slug), label: doc.title };
+    if (doc.segments.length <= 1) {
+      rootLinks.push(link);
+    } else {
+      const folder = doc.segments[0];
+      if (!sectionsByFolder.has(folder)) {
+        sectionsByFolder.set(folder, []);
+      }
+      sectionsByFolder.get(folder)!.push(link);
+    }
+  }
+
+  const sections: Section[] = [];
+  if (rootLinks.length > 0) {
+    sections.push({ title: 'Getting Started', links: rootLinks });
+  }
+  for (const [folder, links] of sectionsByFolder) {
+    sections.push({ title: humanize(folder), links });
+  }
+  return sections;
+}
+
+const sections = buildSections();
 
 export default function DocSidebar() {
   const [open, setOpen] = useState(false);

--- a/website/src/components/MarkdownPage.tsx
+++ b/website/src/components/MarkdownPage.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect } from 'react';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
@@ -9,30 +8,11 @@ import '@/styles/components/doc-content.css';
 import '@/styles/components/sidebar.css';
 
 interface MarkdownPageProps {
-  path: string;
+  content: string;
   title: string;
 }
 
-export default function MarkdownPage({ path, title }: MarkdownPageProps) {
-  const [content, setContent] = useState('');
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetch(`/docs/${path}`)
-      .then((res) => {
-        if (!res.ok) throw new Error('Not found');
-        return res.text();
-      })
-      .then((text) => {
-        setContent(text);
-        setLoading(false);
-      })
-      .catch(() => {
-        setContent('# Page not found\n\nThis documentation page could not be loaded.');
-        setLoading(false);
-      });
-  }, [path]);
-
+export default function MarkdownPage({ content, title }: MarkdownPageProps) {
   return (
     <>
       <Head>
@@ -41,32 +21,26 @@ export default function MarkdownPage({ path, title }: MarkdownPageProps) {
       <div className="doc-layout">
         <DocSidebar />
         <div className="doc-content-area">
-          {loading ? (
-            <article className="doc-content">
-              <div style={{ color: 'var(--color-text-muted)' }}>Loading...</div>
-            </article>
-          ) : (
-            <article className="doc-content">
-              <Markdown
-                remarkPlugins={[remarkGfm]}
-                rehypePlugins={[rehypeRaw]}
-                components={{
-                  code({ className, children, ...props }) {
-                    const match = /language-(\w+)/.exec(className || '');
-                    const code = String(children).replace(/\n$/, '');
+          <article className="doc-content">
+            <Markdown
+              remarkPlugins={[remarkGfm]}
+              rehypePlugins={[rehypeRaw]}
+              components={{
+                code({ className, children, ...props }) {
+                  const match = /language-(\w+)/.exec(className || '');
+                  const code = String(children).replace(/\n$/, '');
 
-                    if (match) {
-                      return <CodeBlock code={code} language={match[1]} />;
-                    }
+                  if (match) {
+                    return <CodeBlock code={code} language={match[1]} />;
+                  }
 
-                    return <code className={className} {...props}>{children}</code>;
-                  },
-                }}
-              >
-                {content}
-              </Markdown>
-            </article>
-          )}
+                  return <code className={className} {...props}>{children}</code>;
+                },
+              }}
+            >
+              {content}
+            </Markdown>
+          </article>
         </div>
       </div>
     </>

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -1,0 +1,50 @@
+export interface DocEntry {
+  slug: string;
+  content: string;
+  title: string;
+  segments: string[];
+}
+
+function extractTitle(markdown: string): string {
+  for (const rawLine of markdown.split('\n')) {
+    const line = rawLine.trim();
+    if (line.startsWith('# ')) {
+      return line.slice(2).trim();
+    }
+  }
+  return '';
+}
+
+function humanize(segment: string): string {
+  return segment
+    .split(/[-_]/)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+const ctx = require.context('@docs', true, /\.md$/, 'sync');
+
+const docs: DocEntry[] = ctx.keys().map((key) => {
+  const relPath = key.replace(/^\.\//, '').replace(/\.md$/, '');
+  const slug = relPath.replace(/\/?index$/, '');
+  const segments = slug.split('/').filter(Boolean);
+  const content = ctx<string>(key);
+  const title = extractTitle(content) || humanize(segments[segments.length - 1] || 'Overview');
+  return { slug, content, title, segments };
+});
+
+const bySlug = new Map(docs.map((doc) => [doc.slug, doc]));
+
+export function getDoc(slug: string): DocEntry | undefined {
+  return bySlug.get(slug);
+}
+
+export function getAllDocs(): DocEntry[] {
+  return docs;
+}
+
+export function docToUrl(slug: string): string {
+  return slug === '' ? '/documentation' : `/documentation/${slug}`;
+}
+
+export { humanize };

--- a/website/src/pages/documentation/[...path].tsx
+++ b/website/src/pages/documentation/[...path].tsx
@@ -1,25 +1,16 @@
-import { useParams } from 'react-router-dom';
+import { useLocation } from 'react-router-dom';
 import MarkdownPage from '@/components/MarkdownPage';
+import { getDoc } from '@/lib/docs';
 
-const PATH_MAP: Record<string, { file: string; title: string }> = {
-  '': { file: 'index.md', title: 'Overview' },
-  'installation': { file: 'getting-started/installation.md', title: 'Installation' },
-  'quick-start': { file: 'getting-started/quick-start.md', title: 'Quick Start' },
-  'routing/file-based': { file: 'routing/file-based.md', title: 'File-based Routing' },
-  'routing/layouts': { file: 'routing/layouts.md', title: 'Layouts' },
-  'routing/dynamic-routes': { file: 'routing/dynamic-routes.md', title: 'Dynamic Routes' },
-  'configuration': { file: 'configuration/overview.md', title: 'Configuration' },
-  'configuration/rspack': { file: 'configuration/rspack.md', title: 'Custom Rspack Config' },
-  'configuration/runtime': { file: 'configuration/runtime.md', title: 'Runtime Configuration' },
-  'cli': { file: 'cli/commands.md', title: 'CLI Commands' },
-  'api': { file: 'api/components.md', title: 'API Reference' },
+const NOT_FOUND = {
+  content: '# Page not found\n\nThis documentation page does not exist.',
+  title: 'Page not found',
 };
 
 export default function DocPage() {
-  const params = useParams();
-  const path = params['*'] || '';
+  const { pathname } = useLocation();
+  const slug = pathname.replace(/^\/documentation\/?/, '').replace(/\/$/, '');
+  const page = getDoc(slug) ?? NOT_FOUND;
 
-  const page = PATH_MAP[path] || { file: path + '.md', title: 'Documentation' };
-
-  return <MarkdownPage path={page.file} title={`${page.title} - Aplos Docs`} />;
+  return <MarkdownPage content={page.content} title={`${page.title} - Aplos Docs`} />;
 }

--- a/website/src/webpack-env.d.ts
+++ b/website/src/webpack-env.d.ts
@@ -1,0 +1,21 @@
+interface RequireContext {
+  keys(): string[];
+  (id: string): unknown;
+  <T>(id: string): T;
+  resolve(id: string): string;
+  id: string;
+}
+
+interface NodeRequire {
+  context(
+    directory: string,
+    useSubdirectories?: boolean,
+    regExp?: RegExp,
+    mode?: 'sync' | 'lazy' | 'lazy-once' | 'eager' | 'weak'
+  ): RequireContext;
+}
+
+declare module '*.md' {
+  const content: string;
+  export default content;
+}


### PR DESCRIPTION
## Summary

- **Framework** — `src/build/router.js` accepts a `paths` field (array or function) on route entries. Each value expands the matching catch-all route into a concrete static node sharing the catch-all's component, so the SSG can pre-render every URL without splitting the catch-all into many files.
- **Website (dogfooding)** — the docs site uses this to auto-discover every `.md` under `documentation/` and register each as a static route. New rspack alias `@docs` + md loader; `docs.ts` walks the dir via `require.context` and feeds `paths` in `aplos.config.js`. `MarkdownPage` now receives content as a prop instead of fetching at runtime, so each page ships fully pre-rendered.
- Verified end-to-end: `bun run build` in `website/` pre-renders 12 doc HTML files (one per `.md`), zero manual list to maintain.