### PR TITLE
feat(ssg): per-instance meta for routes expanded via paths

### DIFF
--- a/documentation/api/meta.md
+++ b/documentation/api/meta.md
@@ -76,6 +76,63 @@ Pages rendered as a SPA (no static directive) do not get build-time meta. For
 those, use the runtime `aplos/head` component to set tags from inside your
 React tree.
 
+## Per-instance meta for dynamic routes
+
+A page that is expanded across many concrete URLs via the `paths` config (for
+example, a docs catch-all `/documentation/[...path]`) shares one component
+file — so a single static `meta` object would apply to every URL. To give each
+URL its own metadata, use one of the two forms below.
+
+### Function form
+
+Export `meta` as a function. Aplos calls it once per concrete URL during the
+static render, passing the URL and the route params extracted from the page's
+source pattern.
+
+```tsx
+// src/pages/documentation/[...path].tsx
+"use static";
+
+export const meta = (url, params) => ({
+  title: `${getDocTitle(params.path)} — Acme Docs`,
+  description: getDocSummary(params.path),
+  canonical: `https://acme.example${url}`,
+});
+
+export default function DocPage() { /* … */ }
+```
+
+`params` keys come from the bracketed segments of the route source: `[slug]`
+becomes `params.slug`, `[...path]` becomes `params.path` (joined with `/`).
+
+### Inline meta on `paths` entries
+
+Alternatively, declare the meta next to each path in `aplos.config.js`. Each
+entry can be a string (just the path) or an object `{ path, meta }`:
+
+```js
+// aplos.config.js
+export default {
+  routes: [
+    {
+      source: '/documentation/[...path]',
+      paths: () => walkDocs().map(slug => ({
+        path: `/documentation/${slug}`,
+        meta: {
+          title: `${titleFor(slug)} — Acme Docs`,
+          description: summaryFor(slug),
+          canonical: `https://acme.example/documentation/${slug}`,
+        },
+      })),
+    },
+  ],
+};
+```
+
+Inline `meta` wins over the component-level `meta` export when both are
+present. Strings in `paths` still work and fall back to the component-level
+`meta`.
+
 ## Combining with global head defaults
 
 `aplos.config.js` lets you set global head defaults (default title, viewport,

--- a/src/build/router.js
+++ b/src/build/router.js
@@ -116,8 +116,20 @@ export async function buildRouter(aplos) {
             console.warn(`Route config: paths for "${entry.source}" must be an array or a function returning one.`);
             continue;
         }
-        for (const concretePath of paths) {
-            if (typeof concretePath !== 'string' || !concretePath.startsWith('/')) {
+        for (const rawEntry of paths) {
+            let concretePath;
+            let inlineMeta = null;
+            if (typeof rawEntry === 'string') {
+                concretePath = rawEntry;
+            } else if (rawEntry && typeof rawEntry === 'object' && typeof rawEntry.path === 'string') {
+                concretePath = rawEntry.path;
+                if (rawEntry.meta && typeof rawEntry.meta === 'object') {
+                    inlineMeta = rawEntry.meta;
+                }
+            } else {
+                continue;
+            }
+            if (!concretePath.startsWith('/')) {
                 continue;
             }
             if (pages.find(p => p.path === concretePath)) {
@@ -129,6 +141,8 @@ export async function buildRouter(aplos) {
                 file: catchAll.file,
                 requirement: {},
                 static: true,
+                sourcePath: entry.source,
+                inlineMeta,
             });
         }
     }
@@ -280,9 +294,14 @@ function serializeRouteTree(nodes, indent = '') {
         const parts = [];
         if (node.component) {
             parts.push(`${inner}element: ${node.component}`);
-            parts.push(`${inner}meta: ${node.component}__meta`);
+            if (node.inlineMeta) {
+                parts.push(`${inner}meta: ${JSON.stringify(node.inlineMeta)}`);
+            } else {
+                parts.push(`${inner}meta: ${node.component}__meta`);
+            }
         }
         if (node.path !== undefined) parts.push(`${inner}path: ${JSON.stringify(node.path)}`);
+        if (node.sourcePath) parts.push(`${inner}sourcePath: ${JSON.stringify(node.sourcePath)}`);
         if (node.static === true) parts.push(`${inner}static: true`);
         if (node.children) {
             parts.push(`${inner}children: ${serializeRouteTree(node.children, inner)}`);
@@ -469,6 +488,12 @@ function buildNestedRoutes(pages, layoutTree) {
             const node = { path: page.path, component: page.component };
             if (page.static) {
                 node.static = true;
+            }
+            if (page.sourcePath) {
+                node.sourcePath = page.sourcePath;
+            }
+            if (page.inlineMeta) {
+                node.inlineMeta = page.inlineMeta;
             }
             nodes.push(node);
         });

--- a/src/runtime/ssr-entry.jsx
+++ b/src/runtime/ssr-entry.jsx
@@ -52,16 +52,51 @@ function findRouteModule(nodes, url) {
     return null;
 }
 
+function extractParams(sourcePath, url) {
+    if (!sourcePath) {
+        return {};
+    }
+    const sourceSegments = sourcePath.split('/').filter(Boolean);
+    const urlSegments = url.split('/').filter(Boolean);
+    const params = {};
+    for (let i = 0; i < sourceSegments.length; i++) {
+        const seg = sourceSegments[i];
+        const catchAll = seg.match(/^\[\.\.\.(.+)\]$/);
+        if (catchAll) {
+            params[catchAll[1]] = urlSegments.slice(i).join('/');
+            return params;
+        }
+        const dynamic = seg.match(/^\[(.+)\]$/);
+        if (dynamic) {
+            params[dynamic[1]] = urlSegments[i];
+        }
+    }
+    return params;
+}
+
 /**
  * Return the `meta` export of the page module matching `url`, if any.
- * Pages opt in by exporting `export const meta = { title, description, ... }`.
+ * Pages opt in by exporting `export const meta = { title, description, ... }`
+ * or `export const meta = (url, params) => ({ ... })` for per-instance values.
+ * When the matched node carries an inline `meta` (from a `paths` entry), that
+ * value wins over the component-level export.
  * @param {string} url
  * @returns {object|null}
  */
 export function getRouteMeta(url) {
     const node = findRouteModule(routeTree, url);
-    if (!node || !node.meta) {
+    if (!node || node.meta === undefined || node.meta === null) {
         return null;
+    }
+    if (typeof node.meta === 'function') {
+        const params = extractParams(node.sourcePath, url);
+        try {
+            const result = node.meta(url, params);
+            return result && typeof result === 'object' ? result : null;
+        } catch (err) {
+            console.error(`meta() threw for ${url}:`, err.message);
+            return null;
+        }
     }
     return node.meta;
 }

--- a/tests/build/per-route-meta.test.js
+++ b/tests/build/per-route-meta.test.js
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { buildRouter } from '../../src/build/router.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+describe('per-route meta for dynamic paths', () => {
+    const testProjectDir = '/tmp/aplos-per-route-meta-test';
+    const cacheDir = path.join(testProjectDir, '.aplos', 'cache');
+
+    beforeAll(async () => {
+        const pagesDir = path.join(testProjectDir, 'src', 'pages');
+        await fs.mkdir(path.join(pagesDir, 'documentation'), { recursive: true });
+
+        await fs.writeFile(
+            path.join(pagesDir, 'documentation', '[...path].tsx'),
+            `"use static";
+export const meta = (url, params) => ({ title: 'Doc ' + params.path, canonical: 'https://x.test' + url });
+export default () => null;
+`
+        );
+    });
+
+    afterAll(async () => {
+        await fs.rm(testProjectDir, { recursive: true, force: true });
+    });
+
+    test('inline meta on a paths entry is serialized into routes.js', async () => {
+        const originalCwd = process.cwd;
+        process.cwd = () => testProjectDir;
+        try {
+            await buildRouter({
+                routes: [
+                    {
+                        source: '/documentation/[...path]',
+                        paths: [
+                            { path: '/documentation/intro', meta: { title: 'Intro' } },
+                            '/documentation/quickstart',
+                        ],
+                    },
+                ],
+            });
+
+            const routesContent = await fs.readFile(path.join(cacheDir, 'routes.js'), 'utf-8');
+
+            // Inline meta is emitted as JSON next to the concrete path.
+            expect(routesContent).toContain('"/documentation/intro"');
+            expect(routesContent).toContain('"title":"Intro"');
+
+            // The string-only path falls back to the component-level meta alias.
+            expect(routesContent).toContain('"/documentation/quickstart"');
+            expect(routesContent).toMatch(/meta: DocumentationPath__meta,[\s\S]*?path: "\/documentation\/quickstart"/);
+
+            // sourcePath is preserved on expanded nodes so runtime can extract params.
+            expect(routesContent).toContain('sourcePath: "/documentation/[...path]"');
+        } finally {
+            process.cwd = originalCwd;
+        }
+    });
+
+    test('inline meta has precedence over component-level meta', async () => {
+        const routesContent = await fs.readFile(path.join(cacheDir, 'routes.js'), 'utf-8');
+        // Find the block containing the intro path, walking back to its opening "{".
+        const introIdx = routesContent.indexOf('"/documentation/intro"');
+        expect(introIdx).toBeGreaterThan(-1);
+        const blockStart = routesContent.lastIndexOf('{', introIdx);
+        const blockEnd = routesContent.indexOf('}', introIdx);
+        const introBlock = routesContent.slice(blockStart, blockEnd + 1);
+
+        expect(introBlock).toContain('"title":"Intro"');
+        expect(introBlock).not.toContain('DocumentationPath__meta');
+    });
+
+    test('pages.js still re-exports a single __meta per component', async () => {
+        const pagesContent = await fs.readFile(path.join(cacheDir, 'pages.js'), 'utf-8');
+        const occurrences = pagesContent.match(/export const DocumentationPath__meta = /g) || [];
+        expect(occurrences.length).toBe(1);
+    });
+});
+
+describe('getRouteMeta param extraction', () => {
+    // The function lives inside ssr-entry.jsx and is exercised end-to-end by
+    // the SSG bundle. We re-implement the same param extractor here to lock
+    // its contract, then test the wired routes.js as a smoke test above.
+    function extractParams(sourcePath, url) {
+        if (!sourcePath) return {};
+        const sourceSegments = sourcePath.split('/').filter(Boolean);
+        const urlSegments = url.split('/').filter(Boolean);
+        const params = {};
+        for (let i = 0; i < sourceSegments.length; i++) {
+            const seg = sourceSegments[i];
+            const catchAll = seg.match(/^\[\.\.\.(.+)\]$/);
+            if (catchAll) {
+                params[catchAll[1]] = urlSegments.slice(i).join('/');
+                return params;
+            }
+            const dynamic = seg.match(/^\[(.+)\]$/);
+            if (dynamic) {
+                params[dynamic[1]] = urlSegments[i];
+            }
+        }
+        return params;
+    }
+
+    test('extracts catch-all rest as joined slash path', () => {
+        expect(extractParams('/documentation/[...path]', '/documentation/api/meta'))
+            .toEqual({ path: 'api/meta' });
+    });
+
+    test('extracts single dynamic param', () => {
+        expect(extractParams('/blog/[id]', '/blog/42')).toEqual({ id: '42' });
+    });
+
+    test('extracts mixed dynamic + catch-all', () => {
+        expect(extractParams('/app/[tenant]/docs/[...rest]', '/app/acme/docs/a/b'))
+            .toEqual({ tenant: 'acme', rest: 'a/b' });
+    });
+
+    test('returns empty object when no source path', () => {
+        expect(extractParams(null, '/whatever')).toEqual({});
+    });
+});


### PR DESCRIPTION
## Summary

Closes the gap left by #11: pages expanded across many concrete URLs via `paths` now get **per-instance** `<title>` / description / canonical at build time, not the same meta block N times.

Two opt-in shapes are supported:

**Function form** — `meta` is called once per concrete URL with `(url, params)`:

```tsx
// src/pages/documentation/[...path].tsx
export const meta = (url, params) => ({
  title: `${titleFor(params.path)} — Docs`,
  canonical: `https://example.com${url}`,
});
```

**Inline form** — declare meta next to each path in `aplos.config.js`:

```js
paths: () => walkDocs().map(slug => ({
  path: `/documentation/${slug}`,
  meta: { title: titleFor(slug), description: summaryFor(slug) },
})),
```

Inline meta wins over the component-level export. Strings in `paths` still work and fall back to the component-level `meta`.

## Implementation

- `router.js`: accept `{ path, meta }` in `paths` alongside strings; carry `sourcePath` + inline meta onto each expanded page node so the route tree keeps the original pattern (`/documentation/[...path]`) next to the concrete URL.
- `serializeRouteTree`: emit `meta: <JSON>` when inline meta is present, otherwise fall back to the existing `${Component}__meta` alias.
- `ssr-entry.getRouteMeta`: if `node.meta` is a function, extract params from `sourcePath` (`[id]` → string, `[...rest]` → joined remainder), call `meta(url, params)`, and tolerate throws by logging and returning `null`.
- Documentation in `documentation/api/meta.md` (new "Per-instance meta for dynamic routes" section).

## Test plan

- [x] `bun test` — 36 pass, 0 fail (7 new tests in `tests/build/per-route-meta.test.js`)
- [x] CI on PR — both `test` jobs pass
- [x] **End-to-end dogfood**: sandbox project with `documentation/[...path].tsx` exporting `meta` as a function + `aplos.config.js` declaring `paths` with mixed string and `{path, meta}` entries. Built with `aplos build --static`. Verified the pre-rendered HTMLs:

  | Pre-rendered file | Source | `<title>` | canonical |
  |---|---|---|---|
  | `index.html` | component `meta` object | `Home — Acme` | — |
  | `documentation/intro.html` | inline meta on `paths` entry | `Intro — Acme Docs` | `…/intro` |
  | `documentation/quickstart.html` | fallback to `meta()` function | `quickstart — Acme Docs (fn)` | `…/quickstart` |
  | `documentation/api/meta.html` | `meta()` with `params.path = "api/meta"` | `api/meta — Acme Docs (fn)` | `…/api/meta` |

  Confirms: (a) inline meta wins over the function meta on the same route, (b) `params.path` is correctly joined with `/` for nested catch-all URLs.