### PR TITLE
fix(ssg): skip namespace import for pages without a meta export

### DIFF
--- a/src/build/router.js
+++ b/src/build/router.js
@@ -165,12 +165,16 @@ export async function buildRouter(aplos) {
         const componentFileName = page.file.replace('~', '');
         pagesExports.push(`export { default as ${page.component} } from "${projectDirectory}/src/pages${componentFileName}";`);
         // Re-export the optional `meta` named export under a deterministic alias.
-        // Importing a non-existent named export is a no-op in module systems we
-        // target (Rspack/Babel compile to undefined when missing), but to stay
-        // safe across loaders we wrap each meta import in its own module via
-        // import * as.
-        pagesExports.push(`import * as ${page.component}__module from "${projectDirectory}/src/pages${componentFileName}";`);
-        pagesExports.push(`export const ${page.component}__meta = ${page.component}__module.meta || null;`);
+        // Only emit the namespace import when the source file actually exports
+        // `meta` — otherwise rspack/webpack fires an ESModulesLinkingWarning
+        // per page that doesn't opt in, drowning real warnings on large sites.
+        const absolutePageFile = `${pageDirectory}${componentFileName}`;
+        if (pageHasMetaExport(absolutePageFile)) {
+            pagesExports.push(`import * as ${page.component}__module from "${projectDirectory}/src/pages${componentFileName}";`);
+            pagesExports.push(`export const ${page.component}__meta = ${page.component}__module.meta || null;`);
+        } else {
+            pagesExports.push(`export const ${page.component}__meta = null;`);
+        }
     });
 
     // Layout exports
@@ -327,6 +331,46 @@ function generateHeadFile(head, reactStrictMode) {
     lines.push(`export default ${JSON.stringify(headObj, null, 2)};`);
     lines.push(`export const reactStrictMode = ${!!reactStrictMode};`);
     return lines.join('\n') + '\n';
+}
+
+/**
+ * Detect whether a page module exports a `meta` named binding. Used by the
+ * router generator to decide whether to emit the `import * as ...__module`
+ * re-export pair (rspack warns on namespace access for missing named exports).
+ *
+ * We use a deliberately permissive regex: false positives only emit the same
+ * code we used to emit unconditionally — no harm done. The patterns covered:
+ *   export const meta
+ *   export let meta
+ *   export var meta
+ *   export function meta
+ *   export async function meta
+ *   export { meta }   (also { meta as ... } / { foo as meta })
+ *
+ * Exports inside line/block comments are filtered out before scanning so
+ * commented-out examples in the source don't trigger a match.
+ *
+ * @param {string} filePath
+ * @returns {boolean}
+ */
+function pageHasMetaExport(filePath) {
+    let source;
+    try {
+        source = fs.readFileSync(filePath, 'utf-8');
+    } catch (error) {
+        return false;
+    }
+    // Strip block and line comments to avoid matching commented-out exports.
+    const stripped = source
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+    if (/export\s+(?:const|let|var|function|async\s+function)\s+meta\b/.test(stripped)) {
+        return true;
+    }
+    if (/export\s*\{[^}]*\bmeta\b[^}]*\}/.test(stripped)) {
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/tests/build/meta-export-detection.test.js
+++ b/tests/build/meta-export-detection.test.js
@@ -1,0 +1,75 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { buildRouter } from '../../src/build/router.js';
+import fs from 'fs/promises';
+import path from 'path';
+
+describe('pages.js skips namespace import when no `meta` export', () => {
+    const testProjectDir = '/tmp/aplos-meta-export-detection-test';
+    const cacheDir = path.join(testProjectDir, '.aplos', 'cache');
+
+    beforeAll(async () => {
+        const pagesDir = path.join(testProjectDir, 'src', 'pages');
+        await fs.mkdir(pagesDir, { recursive: true });
+
+        await fs.writeFile(
+            path.join(pagesDir, 'no-meta.tsx'),
+            `export default function Page() { return null; }\n`
+        );
+        await fs.writeFile(
+            path.join(pagesDir, 'with-const.tsx'),
+            `export const meta = { title: 'X' };\nexport default function Page() { return null; }\n`
+        );
+        await fs.writeFile(
+            path.join(pagesDir, 'with-fn.tsx'),
+            `export function meta(url, params) { return { title: url }; }\nexport default function Page() { return null; }\n`
+        );
+        await fs.writeFile(
+            path.join(pagesDir, 'with-named.tsx'),
+            `const meta = { title: 'N' };\nexport { meta };\nexport default function Page() { return null; }\n`
+        );
+        await fs.writeFile(
+            path.join(pagesDir, 'with-commented.tsx'),
+            `// export const meta = { title: 'oops' };\nexport default function Page() { return null; }\n`
+        );
+
+        const originalCwd = process.cwd;
+        process.cwd = () => testProjectDir;
+        try {
+            await buildRouter({ routes: [] });
+        } finally {
+            process.cwd = originalCwd;
+        }
+    });
+
+    afterAll(async () => {
+        await fs.rm(testProjectDir, { recursive: true, force: true });
+    });
+
+    test('emits direct `null` for a page without `meta`', async () => {
+        const pagesContent = await fs.readFile(path.join(cacheDir, 'pages.js'), 'utf-8');
+        expect(pagesContent).toContain('export const Nometa__meta = null;');
+        expect(pagesContent).not.toContain('Nometa__module');
+    });
+
+    test('emits namespace import for `export const meta`', async () => {
+        const pagesContent = await fs.readFile(path.join(cacheDir, 'pages.js'), 'utf-8');
+        expect(pagesContent).toContain('import * as Withconst__module');
+        expect(pagesContent).toContain('Withconst__meta = Withconst__module.meta || null');
+    });
+
+    test('emits namespace import for `export function meta`', async () => {
+        const pagesContent = await fs.readFile(path.join(cacheDir, 'pages.js'), 'utf-8');
+        expect(pagesContent).toContain('import * as Withfn__module');
+    });
+
+    test('emits namespace import for `export { meta }`', async () => {
+        const pagesContent = await fs.readFile(path.join(cacheDir, 'pages.js'), 'utf-8');
+        expect(pagesContent).toContain('import * as Withnamed__module');
+    });
+
+    test('ignores `meta` inside a line comment', async () => {
+        const pagesContent = await fs.readFile(path.join(cacheDir, 'pages.js'), 'utf-8');
+        expect(pagesContent).toContain('export const Withcommented__meta = null;');
+        expect(pagesContent).not.toContain('Withcommented__module');
+    });
+});


### PR DESCRIPTION
## Summary

Eliminates the `ESModulesLinkingWarning: export 'meta' was not found` warnings rspack emits — one per page that doesn't export `meta` — by only generating the `import * as Component__module` line for pages that actually export `meta`. Pages without `meta` now get `export const Component__meta = null;` directly.

On a project with ~37 pages and one `meta`, this drops the build output from 36 spurious warnings to zero. On docs-heavy sites the impact is bigger.

## Implementation

- New helper `pageHasMetaExport(filePath)` in `src/build/router.js` regex-scans each page source after stripping line/block comments, looking for `export const|let|var|function|async function meta` or `export { ... meta ... }`.
- The `pages.forEach` block branches on this: emit the namespace import + `__meta = __module.meta || null` only when `meta` is present, otherwise emit `__meta = null;` directly.
- False positives are safe (they just emit the code we used to emit unconditionally); false negatives only happen for exotic re-export shapes that the SSG meta extractor wouldn't pick up anyway.

## Test plan

- [x] `bun test` — 41 pass, 0 fail (5 new tests in `tests/build/meta-export-detection.test.js` covering `export const meta`, `export function meta`, `export { meta }`, no-meta page, and commented-out `meta`)
- [x] **End-to-end dogfood**: sandbox project with one page exporting `meta`, one page exporting `meta` as a function, and one page (`/about`) with no `meta`. Built with `aplos build --static`. Verified:
  - Generated `.aplos/cache/pages.js` shows `About__meta = null;` directly, no `About__module` import.
  - Pages with `meta` still get the namespace import.
  - Build output has zero `ESModulesLinkingWarning`s.
  - All 5 pre-rendered HTMLs still get the correct `<title>` (per-route meta from #12 still works).

Closes the third ticket in `.issues/`.