### PR TITLE
Ship TypeScript declarations for public entrypoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,9 +84,21 @@
     "react-router-dom": "^7.0.0"
   },
   "exports": {
-    "./config": "./src/config.js",
-    "./navigation": "./src/components/navigation.jsx",
-    "./head": "./src/components/head.jsx",
-    "./redirect": "./src/runtime/redirect.js"
+    "./config": {
+      "types": "./src/config.d.ts",
+      "default": "./src/config.js"
+    },
+    "./navigation": {
+      "types": "./src/components/navigation.d.ts",
+      "default": "./src/components/navigation.jsx"
+    },
+    "./head": {
+      "types": "./src/components/head.d.ts",
+      "default": "./src/components/head.jsx"
+    },
+    "./redirect": {
+      "types": "./src/runtime/redirect.d.ts",
+      "default": "./src/runtime/redirect.js"
+    }
   }
 }

--- a/src/components/head.d.ts
+++ b/src/components/head.d.ts
@@ -1,0 +1,7 @@
+import type { ReactNode } from "react";
+
+/**
+ * Imperatively syncs its children (title, meta, link, script, html/body
+ * attributes) into the document head. Renders nothing.
+ */
+export default function Head(props: { children?: ReactNode }): null;

--- a/src/components/navigation.d.ts
+++ b/src/components/navigation.d.ts
@@ -1,0 +1,11 @@
+export {
+	Link,
+	NavLink,
+	Navigate,
+	Outlet,
+	useNavigate,
+	useLocation,
+	useParams,
+	useSearchParams,
+	useMatch,
+} from "react-router-dom";

--- a/src/config.d.ts
+++ b/src/config.d.ts
@@ -1,0 +1,70 @@
+/**
+ * Server configuration block.
+ */
+export interface AplosServerConfig {
+	port?: number | string;
+}
+
+/**
+ * A single head tag entry (meta, link, script, …). Attributes are free-form
+ * since they map directly to HTML attributes.
+ */
+export type AplosHeadTag = Record<string, string | number | boolean | undefined>;
+
+/**
+ * Head configuration used to render the document <head>.
+ */
+export interface AplosHeadConfig {
+	defaultTitle?: string;
+	titleTemplate?: string;
+	htmlAttributes?: Record<string, string>;
+	meta?: AplosHeadTag[];
+	link?: AplosHeadTag[];
+	script?: AplosHeadTag[];
+}
+
+/**
+ * A route rewrite/redirect or a programmatic route definition.
+ */
+export interface AplosRoute {
+	source?: string;
+	destination?: string;
+	path?: string;
+	component?: string;
+	file?: string;
+	requirements?: Record<string, string>;
+}
+
+/**
+ * Base shape of an `aplos.config.js` export. Projects typically extend this
+ * with their own `publicRuntimeConfig` fields, so additional keys are allowed.
+ *
+ * To get precise typing for project-specific keys, pass your own config type
+ * as the generic argument to {@link getConfig}.
+ */
+export interface AplosConfig {
+	reactStrictMode?: boolean;
+	server?: AplosServerConfig;
+	head?: AplosHeadConfig;
+	routes?: AplosRoute[];
+	publicRuntimeConfig?: Record<string, unknown>;
+	[key: string]: unknown;
+}
+
+/**
+ * Returns the resolved Aplos configuration (merged defaults + `aplos.config.js`).
+ *
+ * Pass a project-specific config type to get precise typing for custom keys
+ * such as `publicRuntimeConfig`:
+ *
+ * @example
+ *   import getConfig from 'aplos/config';
+ *
+ *   interface MyConfig extends AplosConfig {
+ *     publicRuntimeConfig: { api_base_url: string };
+ *   }
+ *
+ *   const { publicRuntimeConfig } = getConfig<MyConfig>();
+ *   publicRuntimeConfig.api_base_url; // typed as string
+ */
+export default function getConfig<T extends AplosConfig = AplosConfig>(): T;

--- a/src/runtime/redirect.d.ts
+++ b/src/runtime/redirect.d.ts
@@ -1,0 +1,25 @@
+/**
+ * Sentinel returned by a route middleware to short-circuit navigation.
+ */
+export interface AplosRedirect {
+	__aplosRedirect: true;
+	to: string;
+	replace: boolean;
+}
+
+export interface RedirectOptions {
+	/** Replace the current history entry instead of pushing a new one. Defaults to `true`. */
+	replace?: boolean;
+}
+
+/**
+ * Ask Aplos to navigate elsewhere before the matched route renders.
+ *
+ * @param to Destination path (e.g. `/login`).
+ */
+export function redirect(to: string, options?: RedirectOptions): AplosRedirect;
+
+/**
+ * Type guard for values returned by {@link redirect}.
+ */
+export function isRedirect(value: unknown): value is AplosRedirect;


### PR DESCRIPTION
## What

Adds `.d.ts` declarations for all four public package entrypoints so consumers get types out of the box. Previously `aplos/config`, `aplos/navigation`, `aplos/head` and `aplos/redirect` resolved to untyped JS, forcing every TypeScript project to hand-write `declare module 'aplos/*'` ambient declarations.

## Changes

- **`src/config.d.ts`** — typed `getConfig`. It is generic so each project can refine its own config shape:
  ```ts
  import getConfig, { type AplosConfig } from 'aplos/config';

  interface MyConfig extends AplosConfig {
    publicRuntimeConfig: { api_base_url: string };
  }

  const { publicRuntimeConfig } = getConfig<MyConfig>();
  publicRuntimeConfig.api_base_url; // string
  ```
  The base `AplosConfig` describes the known keys (`server`, `head`, `routes`, `reactStrictMode`, `publicRuntimeConfig`) and allows arbitrary extra keys, so calling `getConfig()` with no generic still works.
- **`src/runtime/redirect.d.ts`** — `redirect(to, options?)` and `isRedirect(value)` type guard.
- **`src/components/head.d.ts`** — `Head` component props.
- **`src/components/navigation.d.ts`** — re-exports the relevant `react-router-dom` types.
- **`package.json`** — `exports` now declare `types` alongside `default` for each entrypoint.

Each declaration sits next to the file it describes; the `exports` map points TypeScript at them.

## Verification

Validated in an isolated consumer project:
- `getConfig()` and `getConfig<MyConfig>()` type-check.
- `publicRuntimeConfig.api_base_url` is `string` (not `any`); assigning it to a `number` is correctly rejected.

## Notes

- Project-specific config shapes (e.g. a project's exact `publicRuntimeConfig`) stay in the project — the framework only ships the generic base.
- Pre-existing repo type errors in `src/pages/*.tsx` (missing `@types/react`, self-import of `aplos/config`) are unrelated to this change and untouched.