### PR TITLE
fix: anchor rspack persistent cache under XDG_CACHE_HOME

### DIFF
--- a/documentation/configuration/rspack.md
+++ b/documentation/configuration/rspack.md
@@ -73,5 +73,19 @@ export default {
 };
 ```
 
+## Build cache
+
+Aplos uses Rspack's persistent filesystem cache to speed up repeat builds. The client and SSR compilations keep separate caches so they never invalidate each other.
+
+By default the cache lives in `node_modules/.cache/aplos/`. If the `XDG_CACHE_HOME` environment variable is set, the cache is written under `$XDG_CACHE_HOME/aplos/` instead. This matters in CI/CD and on PaaS builders: point `XDG_CACHE_HOME` at a directory that persists between builds and the cache survives across deploys, turning every build after the first into a warm build.
+
+```bash
+# Persist the cache across builds (CI example)
+export XDG_CACHE_HOME=/path/to/persistent/cache
+bun run build
+```
+
+The cache invalidates automatically when `rspack.config.js` or `rspack.ssr.config.js` changes. To force a clean build, delete the cache directory.
+
 !!! warning
     Avoid overriding core framework settings (entry, output.path, internal aliases) as this may break Aplos functionality.

--- a/documentation/deploy/index.md
+++ b/documentation/deploy/index.md
@@ -25,3 +25,7 @@ Aplos builds plain static assets (HTML, JS, CSS) to `public/dist/`. There's no s
 | **Self-hosted nginx** | Server cost | Configurable | Full control |
 
 If you don't have strong preferences, GitHub Pages is the simplest path when you're already on GitHub.
+
+## Faster CI builds
+
+Aplos caches build artifacts on disk. By default the cache lives in `node_modules/.cache/aplos/`, but set `XDG_CACHE_HOME` to a persisted directory and the cache survives across builds — every deploy after the first becomes a warm build. See [Build cache](/documentation/configuration/rspack#build-cache) for details.

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -12,6 +12,20 @@ const __dirname = path.dirname(__filename);
 const isDevelopment = process.env.NODE_ENV !== "production";
 const projectDirectory = process.cwd();
 
+// Rspack's persistent cache defaults to node_modules/.cache/rspack and does NOT
+// honour XDG_CACHE_HOME. On PaaS builders that persist a cache volume via
+// XDG_CACHE_HOME (e.g. Kemeter mounts it at /opt/build-cache), the default
+// location is wiped on every deploy → every deploy is a cold build. Anchor the
+// cache under $XDG_CACHE_HOME/aplos when available so it survives across
+// deploys; fall back to node_modules/.cache locally. `key` keeps the client and
+// SSR caches in separate directories so they never invalidate each other.
+function rspackCacheDir(key) {
+  const base = process.env.XDG_CACHE_HOME
+    ? path.join(process.env.XDG_CACHE_HOME, "aplos")
+    : path.join(projectDirectory, "node_modules", ".cache", "aplos");
+  return path.join(base, key);
+}
+
 // Determine HTML template path
 // Priority: 1. public/index.html (user override), 2. default template
 const defaultTemplate = path.resolve(__dirname, "./src/client/public/index.html");
@@ -170,6 +184,10 @@ const frameworkConfig = {
   devtool: isDevelopment ? "eval-source-map" : "hidden-source-map",
   cache: {
     type: "filesystem",
+    storage: {
+      type: "filesystem",
+      directory: rspackCacheDir("rspack-client"),
+    },
     buildDependencies: {
       config: [path.resolve(__dirname, "rspack.config.js")],
     },

--- a/rspack.ssr.config.js
+++ b/rspack.ssr.config.js
@@ -9,6 +9,17 @@ const __dirname = path.dirname(__filename);
 
 const projectDirectory = process.cwd();
 
+// Anchor the SSR persistent cache under $XDG_CACHE_HOME/aplos when available so
+// it survives across PaaS deploys (rspack defaults to node_modules/.cache and
+// ignores XDG). Separate key from the client cache so they never collide. See
+// the matching helper in rspack.config.js for the full rationale.
+function rspackCacheDir(key) {
+  const base = process.env.XDG_CACHE_HOME
+    ? path.join(process.env.XDG_CACHE_HOME, "aplos")
+    : path.join(projectDirectory, "node_modules", ".cache", "aplos");
+  return path.join(base, key);
+}
+
 // Inherit project aliases/loaders from the client config (e.g. `@docs` alias,
 // `.md` loader). A dedicated `rspack.ssr.config.js` in the project can override.
 let userConfig = {};
@@ -37,6 +48,16 @@ const frameworkConfig = {
   devtool: false,
   stats: "errors-warnings",
   infrastructureLogging: { level: "error" },
+  cache: {
+    type: "filesystem",
+    storage: {
+      type: "filesystem",
+      directory: rspackCacheDir("rspack-ssr"),
+    },
+    buildDependencies: {
+      config: [path.resolve(__dirname, "rspack.ssr.config.js")],
+    },
+  },
   output: {
     path: path.resolve(projectDirectory, "./.aplos/cache"),
     filename: "ssr-bundle.cjs",


### PR DESCRIPTION
## Problem

Rspack's persistent cache defaults to `node_modules/.cache/rspack` and does **not** honour `XDG_CACHE_HOME`. On PaaS builders that persist a cache volume via `XDG_CACHE_HOME` (e.g. Kemeter mounts it at `/opt/build-cache`), the default location is wiped on every deploy — so **every deploy is a cold build**, even though rspack 2.0's cache works fine locally.

The SSR config (`rspack.ssr.config.js`) had no `cache` block at all, so the SSR bundle was always rebuilt from scratch.

## Fix

Anchor both the client and SSR persistent caches under `$XDG_CACHE_HOME/aplos/{rspack-client,rspack-ssr}` when `XDG_CACHE_HOME` is set, falling back to `node_modules/.cache/aplos` locally. Separate keys keep the two caches from invalidating each other; `buildDependencies` on each config invalidates the cache when the config changes.

## Measurements

Benchmarked on a real project (lugha/client, 125 files, rspack 2.0.8):

| Scenario | Time |
|---|---|
| Cold (cache purged) | ~5.4s |
| Warm (cache present) | ~3.0s |

Warm vs cold: **−44%**. The key point is that this warm gain now **survives across deploys** because the cache lands in the persistent volume — previously the cache stayed in `node_modules/.cache` and was discarded on every deploy, so every production build paid the full cold cost.

## Verified

- Cache lands under `$XDG_CACHE_HOME/aplos/{rspack-client,rspack-ssr}` (checked on disk), nothing left in `node_modules/.cache`.
- Build output unchanged: client + SSR bundles build, static routes pre-render correctly.
- No regression on cold builds (the fix only changes cache location, not compile speed).

## Out of scope

Cold builds remain ~5.4s (first deploy / CI without a cache volume). Reducing that is a separate effort (e.g. parallelising the currently-sequential client and SSR compilations).