### PR TITLE
fix: prevent rspack config self-import and silence dotenv tip

### DIFF
--- a/bin/aplos
+++ b/bin/aplos
@@ -5,9 +5,9 @@ import { existsSync } from "node:fs";
 import { resolve } from "node:path";
 
 const projectDir = process.cwd();
-config({ path: resolve(projectDir, ".env") });
+config({ path: resolve(projectDir, ".env"), quiet: true });
 if (existsSync(resolve(projectDir, ".env.local"))) {
-  config({ path: resolve(projectDir, ".env.local"), override: true });
+  config({ path: resolve(projectDir, ".env.local"), override: true, quiet: true });
 }
 
 import { Command } from "commander";

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -166,10 +166,13 @@ if (!isDevelopment && fs.existsSync(userPublicDir)) {
   );
 }
 
-// Load project's rspack.config.js if it exists
+// Load project's rspack.config.js if it exists.
+// Guard against self-import: when aplos runs inside its own repo, the cwd's
+// rspack.config.js IS this file. Importing it would create a circular ESM
+// dependency whose top-level await never settles, silently killing the process.
 let userConfig = {};
 const userConfigPath = path.resolve(projectDirectory, "rspack.config.js");
-if (fs.existsSync(userConfigPath)) {
+if (fs.existsSync(userConfigPath) && userConfigPath !== __filename) {
   try {
     const userModule = await import(pathToFileURL(userConfigPath).href);
     userConfig = userModule.default || userModule;

--- a/rspack.ssr.config.js
+++ b/rspack.ssr.config.js
@@ -33,7 +33,9 @@ if (fs.existsSync(userClientConfigPath)) {
   }
 }
 const userSSRConfigPath = path.resolve(projectDirectory, "rspack.ssr.config.js");
-if (fs.existsSync(userSSRConfigPath)) {
+// Guard against self-import (see rspack.config.js): inside aplos's own repo this
+// path IS the current file, and a circular ESM import would hang the process.
+if (fs.existsSync(userSSRConfigPath) && userSSRConfigPath !== __filename) {
   try {
     const userModule = await import(pathToFileURL(userSSRConfigPath).href);
     userConfig = merge(userConfig, userModule.default || userModule);


### PR DESCRIPTION
## What

- Add a `quiet: true` flag to the `dotenv` `config()` calls in `bin/aplos` to suppress the promotional tip printed since dotenv v17 (`◇ injected env … // tip: … dotenvx.com`).
- Guard the dynamic import of a project-level `rspack.config.js` / `rspack.ssr.config.js` against self-import.

## Why

Running `bin/aplos server` from inside aplos's own repo exited silently right after `✓ Ready`, never starting the dev server.

Root cause: aplos dynamically imports the cwd's `rspack.config.js` to allow user overrides. Inside its own repo that path resolves to the very file being executed, creating a circular ESM import whose top-level `await` never settles, so Node exits (code 13). The same pattern existed in `rspack.ssr.config.js`.

The guard (`userConfigPath !== __filename`) skips the file when it is itself. In normal usage aplos lives in `node_modules`, so the paths never match and behavior is unchanged.

## Testing

- `bin/aplos server` from inside the aplos repo → HTTP 200 (was: silent exit)
- `bin/aplos server` from a consumer project → HTTP 200 (no regression)
- dotenv tip no longer printed
- `bun test` → 49/49 passing