### PR TITLE
Build to dist by default, add --out-dir option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-public/dist
+dist
 .aplos
 
 src/pages

--- a/bin/aplos
+++ b/bin/aplos
@@ -37,6 +37,10 @@ program
     "Pre-render each static route to HTML (SSG). Dynamic routes fall back to SPA.",
     false
   )
+  .option(
+    "--out-dir <dir>",
+    "Directory the build is emitted to, relative to the project root (default: dist, or $APLOS_OUT_DIR)."
+  )
   .action(build);
 
 program

--- a/documentation/api/meta.md
+++ b/documentation/api/meta.md
@@ -34,7 +34,7 @@ export default function About() {
 }
 ```
 
-After `aplos build --static`, `public/dist/about.html` contains:
+After `aplos build --static`, `dist/about.html` contains:
 
 ```html
 <title>About — Acme</title>

--- a/documentation/cli/commands.md
+++ b/documentation/cli/commands.md
@@ -52,7 +52,7 @@ Generate a production build.
 aplos build
 ```
 
-Output goes to `public/dist/`.
+Output goes to `dist/` by default.
 
 **Options:**
 
@@ -60,6 +60,10 @@ Output goes to `public/dist/`.
 |---|---|
 | `--mode <mode>` | Sets the build mode. Defaults to `development`; pass `production` for optimized output. |
 | `--static` | Pre-render opt-in pages to static HTML (SSG). See [Static rendering](/documentation/static-rendering). |
+| `--out-dir <dir>` | Directory the build is emitted to, relative to the project root. Defaults to `dist`. |
+
+The output directory is resolved in this order: the `--out-dir` flag, then the
+`APLOS_OUT_DIR` environment variable, then the `dist` default.
 
 **Examples:**
 
@@ -69,6 +73,12 @@ aplos build --mode production
 
 # Production build with static pre-rendering for opt-in pages
 aplos build --mode production --static
+
+# Emit the build to a custom directory
+aplos build --out-dir build
+
+# Same, via environment variable
+APLOS_OUT_DIR=build aplos build
 ```
 
 ## `aplos router:debug`

--- a/documentation/deploy/github-pages.md
+++ b/documentation/deploy/github-pages.md
@@ -67,7 +67,7 @@ jobs:
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: public/dist
+          path: dist
 
   deploy:
     needs: build
@@ -102,7 +102,7 @@ Add a `CNAME` file to `public/`:
 docs.example.com
 ```
 
-It will be copied to `public/dist/` at build time. Then point your domain's CNAME record at `<username>.github.io`.
+It will be copied to `dist/` at build time. Then point your domain's CNAME record at `<username>.github.io`.
 
 ## SPA fallback
 
@@ -110,7 +110,7 @@ GitHub Pages does not support arbitrary URL rewrites, so client-side routes that
 
 ```yaml
 - name: SPA fallback
-  run: cp public/dist/index.html public/dist/404.html
+  run: cp dist/index.html dist/404.html
 ```
 
 Add this step before `upload-pages-artifact` in the workflow above. With static rendering enabled, you usually don't need this — but it's a safe fallback for any client-only route.

--- a/documentation/deploy/index.md
+++ b/documentation/deploy/index.md
@@ -1,12 +1,12 @@
 # Deploy
 
-Aplos builds plain static assets (HTML, JS, CSS) to `public/dist/`. There's no server runtime to operate — pick any static host you prefer.
+Aplos builds plain static assets (HTML, JS, CSS) to `dist/`. There's no server runtime to operate — pick any static host you prefer.
 
 ## Recommended workflow
 
 1. Mark pages that should be pre-rendered with `"use static"` (see [Static rendering](/documentation/static-rendering)).
 2. Build with `bun run build --static`.
-3. Upload `public/dist/` to your host.
+3. Upload `dist/` to your host.
 
 ## Guides
 

--- a/documentation/deploy/kemeter.md
+++ b/documentation/deploy/kemeter.md
@@ -11,50 +11,40 @@
 
 ## Setup
 
-Deploy an Aplos app with the `node` runtime so Kemeter runs the build (and the cache kicks in).
+Deploy an Aplos app with a JavaScript runtime (`bun` or `node`) so Kemeter runs the build (and the cache kicks in).
 
-### 1. Define build and start scripts
+### 1. Define a build script
 
 In your `package.json`:
 
 ```json
 {
   "scripts": {
-    "build": "aplos build --mode production --static",
-    "start": "serve --single public/dist"
+    "build": "aplos build --mode production --static"
   }
 }
 ```
 
-`serve --single` serves `public/dist/` with an SPA fallback, so any route that isn't a pre-rendered file falls back to `index.html`.
+The build emits static assets to `dist/`.
 
 ### 2. Configure the app on Kemeter
 
-Create an application with the `node` runtime and point it at your repository. Set the build command and the directory to serve:
+Create an application with a `bun` (or `node`) runtime and point it at your repository. Tell Kemeter which directory to serve once the build finishes:
 
 ```bash
-KEMETER_COMMAND_BUILD="bun run build"
-KEMETER_PUBLIC_DIR=public/dist
+KEMETER_PUBLIC_DIR=dist
 ```
 
 | Variable | Value | Purpose |
 |---|---|---|
-| `KEMETER_COMMAND_BUILD` | `bun run build` | Runs your Aplos build after dependencies are installed |
-| `KEMETER_PUBLIC_DIR` | `public/dist` | Directory served once the build finishes (with SPA fallback) |
-| `KEMETER_APPLICATION_PORT` | `8080` | Listen port (default value, override if needed) |
+| `KEMETER_PUBLIC_DIR` | `dist` | Directory served once the build finishes (with SPA fallback) |
 
-`XDG_CACHE_HOME` is injected automatically for build-phase runtimes, so you don't configure caching at all: Aplos picks it up on its own.
+Kemeter installs dependencies and runs your `build` script automatically — when a `package.json` declares a `build` script, no build command needs to be configured. The build cache is persisted across deploys with no setup (Aplos writes its rspack cache to the location Kemeter exposes for that purpose).
 
 ### 3. Deploy
 
-Push to the connected branch. Kemeter runs the full flow:
-
-1. `bun install` installs dependencies
-2. `bun run build` runs `aplos build --static`, producing `public/dist/` and reusing the persistent rspack cache
-3. `serve --single public/dist` serves the assets with SPA fallback
-
-The app comes up on its Kemeter domain over HTTPS once the readiness probe passes.
+Push to the connected branch. Kemeter installs dependencies, runs `aplos build`, then serves `dist/` with an SPA fallback so client-side routes resolve to your app shell. The app comes up on its Kemeter domain over HTTPS once it is ready.
 
 ## Pre-built static assets
 
-If you'd rather build in CI and commit the output, you can use the `static` runtime instead. Note that the `static` runtime serves the repository root and does **not** run a build phase, so it doesn't get the persistent cache. The `node` runtime above is the recommended path for Aplos because it builds on the platform and benefits from caching. For a pure CI-built static deploy to other hosts, see [Other static hosts](/documentation/deploy/static-host).
+If you'd rather build in CI and commit the output, you can use the `static` runtime instead. Note that the `static` runtime serves the repository root and does **not** run a build phase, so it doesn't get the persistent cache. The JavaScript runtime above is the recommended path for Aplos because it builds on the platform and benefits from caching. For a pure CI-built static deploy to other hosts, see [Other static hosts](/documentation/deploy/static-host).

--- a/documentation/deploy/static-host.md
+++ b/documentation/deploy/static-host.md
@@ -10,10 +10,10 @@ Looking for the native platform Aplos is built for? See [Deploy to Kemeter](/doc
 bun run build --static
 ```
 
-The output is in `public/dist/`. Upload that directory's contents to the host.
+The output is in `dist/`. Upload that directory's contents to the host.
 
 ```
-public/dist/
+dist/
 ├── index.html
 ├── about.html
 ├── 404.html
@@ -25,10 +25,10 @@ public/dist/
 
 ## Netlify
 
-Drop the `public/dist/` folder onto netlify.com, or use the CLI:
+Drop the `dist/` folder onto netlify.com, or use the CLI:
 
 ```bash
-bunx netlify deploy --prod --dir public/dist
+bunx netlify deploy --prod --dir dist
 ```
 
 Or wire up Git deploys with a `netlify.toml`:
@@ -36,7 +36,7 @@ Or wire up Git deploys with a `netlify.toml`:
 ```toml
 [build]
   command = "bun run build --static"
-  publish = "public/dist"
+  publish = "dist"
 ```
 
 ## Vercel
@@ -50,7 +50,7 @@ Or commit a `vercel.json`:
 ```json
 {
   "buildCommand": "bun run build --static",
-  "outputDirectory": "public/dist"
+  "outputDirectory": "dist"
 }
 ```
 
@@ -59,17 +59,17 @@ Or commit a `vercel.json`:
 Connect your repository in the Cloudflare dashboard, then set:
 
 - **Build command:** `bun run build --static`
-- **Build output directory:** `public/dist`
+- **Build output directory:** `dist`
 
 ## nginx
 
-Serve `public/dist/` as the document root with a SPA fallback for client-side routes:
+Serve `dist/` as the document root with a SPA fallback for client-side routes:
 
 ```nginx
 server {
     listen 80;
     server_name example.com;
-    root /var/www/my-app/public/dist;
+    root /var/www/my-app/dist;
     index index.html;
 
     location / {
@@ -83,7 +83,7 @@ The `$uri.html` fallback serves pre-rendered pages (`/about` → `/about.html`) 
 ## S3 + CloudFront
 
 ```bash
-aws s3 sync public/dist s3://your-bucket --delete
+aws s3 sync dist s3://your-bucket --delete
 ```
 
 In CloudFront, configure a custom error response: 403/404 → `/index.html` with status 200, so client-side routes resolve.

--- a/documentation/getting-started/quick-start.md
+++ b/documentation/getting-started/quick-start.md
@@ -37,7 +37,7 @@ The page is now served at [/about](http://localhost:3000/about).
 bun run build
 ```
 
-Output lands in `public/dist/` — plain HTML, JS and CSS ready to deploy to any static host.
+Output lands in `dist/` — plain HTML, JS and CSS ready to deploy to any static host.
 
 ## Next steps
 

--- a/documentation/static-rendering.md
+++ b/documentation/static-rendering.md
@@ -13,7 +13,7 @@ export default function About() {
 }
 ```
 
-When you run `bun run build --static`, Aplos emits `public/dist/about.html` containing the fully rendered HTML. Crawlers see the content. The browser displays it before any JavaScript runs.
+When you run `bun run build --static`, Aplos emits `dist/about.html` containing the fully rendered HTML. Crawlers see the content. The browser displays it before any JavaScript runs.
 
 ## Build with static rendering
 
@@ -35,9 +35,9 @@ Output:
 
 ```
 Pre-rendering 3 route(s)...
-  ✓ /          → public/dist/index.html
-  ✓ /about     → public/dist/about.html
-  ✓ /contact   → public/dist/contact.html
+  ✓ /          → dist/index.html
+  ✓ /about     → dist/about.html
+  ✓ /contact   → dist/contact.html
 ```
 
 ## Mix static and dynamic
@@ -79,10 +79,10 @@ export default {
 At build time, each combination is expanded into its own static HTML file:
 
 ```
-public/dist/blog/hello-world.html
-public/dist/blog/second-post.html
-public/dist/products/42.html
-public/dist/products/43.html
+dist/blog/hello-world.html
+dist/blog/second-post.html
+dist/products/42.html
+dist/products/43.html
 ```
 
 ## Per-route metadata

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -12,6 +12,11 @@ const __dirname = path.dirname(__filename);
 const isDevelopment = process.env.NODE_ENV !== "production";
 const projectDirectory = process.cwd();
 
+// Output directory, relative to the project root. Forwarded by `aplos build`
+// (which resolves --out-dir / $APLOS_OUT_DIR / the `dist` default) through the
+// APLOS_OUT_DIR env var, since this config runs in a separate rspack process.
+const outDir = process.env.APLOS_OUT_DIR || "dist";
+
 // Rspack's persistent cache defaults to node_modules/.cache/rspack and does NOT
 // honour XDG_CACHE_HOME. On PaaS builders that persist a cache volume via
 // XDG_CACHE_HOME (e.g. Kemeter mounts it at /opt/build-cache), the default
@@ -156,9 +161,9 @@ if (!isDevelopment && fs.existsSync(userPublicDir)) {
       patterns: [
         {
           from: userPublicDir,
-          to: path.resolve(projectDirectory, "./public/dist"),
+          to: path.resolve(projectDirectory, outDir),
           globOptions: {
-            ignore: ["**/dist/**", "**/index.html"],
+            ignore: ["**/index.html"],
           },
         },
       ],
@@ -225,7 +230,7 @@ const frameworkConfig = {
     sideEffects: false,
   },
   output: {
-    path: path.resolve(process.cwd(), "./public/dist"),
+    path: path.resolve(projectDirectory, outDir),
     publicPath: "/",
     filename: isDevelopment ? "[name].js" : "[name].[contenthash:8].js",
     chunkFilename: isDevelopment ? "[name].js" : "[name].[contenthash:8].js",

--- a/src/build/ssg.js
+++ b/src/build/ssg.js
@@ -46,10 +46,10 @@ async function buildSSRBundle(projectDirectory, frameworkDirectory, mode) {
     });
 }
 
-export default async function ssg({ mode, forceAll = false } = {}) {
+export default async function ssg({ mode, forceAll = false, outDir } = {}) {
     const projectDirectory = process.cwd();
     const frameworkDirectory = path.resolve(__dirname, '../..');
-    const distDir = path.join(projectDirectory, 'public', 'dist');
+    const distDir = path.join(projectDirectory, outDir || process.env.APLOS_OUT_DIR || 'dist');
     const cacheDir = path.join(projectDirectory, '.aplos', 'cache');
 
     const indexHtmlPath = path.join(distDir, 'index.html');

--- a/src/command/build.js
+++ b/src/command/build.js
@@ -10,8 +10,8 @@ const __dirname = path.dirname(__filename);
 
 import fs from 'fs';
 
-const showBundleAnalysis = (projectDirectory) => {
-    const distPath = path.join(projectDirectory, 'public', 'dist');
+const showBundleAnalysis = (projectDirectory, outDir = 'dist') => {
+    const distPath = path.join(projectDirectory, outDir);
     
     if (!fs.existsSync(distPath)) {
         console.log('❌ Dist folder not found');
@@ -65,6 +65,11 @@ export default async (options) => {
     let runtime_dir = __dirname + "/..";
     let node_modules = projectDirectory + "/node_modules";
 
+    // Output directory precedence: explicit --out-dir wins, then $APLOS_OUT_DIR,
+    // then the `dist` default. The resolved value is forwarded to the rspack
+    // sub-process (which reads APLOS_OUT_DIR) and to SSG / bundle analysis.
+    const outDir = options.outDir || process.env.APLOS_OUT_DIR || "dist";
+
     const buildStart = performance.now();
     await buildRouter(await get_config(projectDirectory));
 
@@ -72,7 +77,9 @@ export default async (options) => {
         "--mode=" + options.mode,
         "--config", runtime_dir + "/../rspack.config.js",
         "--entry", runtime_dir + "/runtime/app.jsx"
-    ]);
+    ], {
+        env: { ...process.env, APLOS_OUT_DIR: outDir },
+    });
 
     rspack.stdout.on('data', (data) => {
         console.log(data.toString());
@@ -92,11 +99,11 @@ export default async (options) => {
         console.log(`\n  Built in ${totalTime}ms`);
 
         if (options.mode === 'production' || process.env.NODE_ENV === 'production') {
-            showBundleAnalysis(projectDirectory);
+            showBundleAnalysis(projectDirectory, outDir);
         }
 
         try {
-            await ssg({ mode: options.mode, forceAll: options.static });
+            await ssg({ mode: options.mode, forceAll: options.static, outDir });
         } catch (err) {
             console.error(`SSG failed: ${err.message}`);
             process.exitCode = 1;

--- a/templates/minimal/_gitignore
+++ b/templates/minimal/_gitignore
@@ -1,6 +1,5 @@
 node_modules
 .aplos
-public/dist
 dist
 .env.local
 *.log


### PR DESCRIPTION
Align the build output directory with the ecosystem convention (Vite, Astro, Nuxt): builds now emit to `dist/` instead of `public/dist/`.

Adds an `--out-dir <dir>` option to `aplos build` to override it, resolved as: `--out-dir` flag > `APLOS_OUT_DIR` env var > `dist` default.

Docs updated accordingly.