### PR TITLE
Fix rspack 2.1 persistent cache buildDependencies format

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -196,9 +196,7 @@ const frameworkConfig = {
       type: "filesystem",
       directory: rspackCacheDir("rspack-client"),
     },
-    buildDependencies: {
-      config: [path.resolve(__dirname, "rspack.config.js")],
-    },
+    buildDependencies: [path.resolve(__dirname, "rspack.config.js")],
   },
   stats: isDevelopment ? 'none' : 'normal',
   infrastructureLogging: {

--- a/rspack.ssr.config.js
+++ b/rspack.ssr.config.js
@@ -56,9 +56,7 @@ const frameworkConfig = {
       type: "filesystem",
       directory: rspackCacheDir("rspack-ssr"),
     },
-    buildDependencies: {
-      config: [path.resolve(__dirname, "rspack.ssr.config.js")],
-    },
+    buildDependencies: [path.resolve(__dirname, "rspack.ssr.config.js")],
   },
   output: {
     path: path.resolve(projectDirectory, "./.aplos/cache"),


### PR DESCRIPTION
## Problem

After upgrading to rspack 2.1 (#25), the build fails with `TypeError: (cacheOptions.buildDependencies || []) is not iterable`.

In rspack 2.0.x, the persistent cache accepted the legacy webpack-style `buildDependencies: { config: [...] }` (an object). In 2.1.x, `cache.buildDependencies` must be a flat array of paths; rspack iterates it directly (`deps.map(...)`), so the object form throws.

## Changes

`rspack.config.js` and `rspack.ssr.config.js`: `buildDependencies: { config: [path] }` -> `buildDependencies: [path]`.

## Validation

Verified against rspack **2.1.1** (not the 1.7.11 that the website resolves by default): forced 2.1.1 in the website workspace and ran a full `aplos build`. rspack compiles successfully and all 20 routes pre-render, confirming both client and SSR configs work.