### PR TITLE
Add missing meta charset to default HTML template

### DIFF
--- a/src/client/public/index.html
+++ b/src/client/public/index.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
The default HTML template ships no `<meta charset>`. When a static host serves
`text/html` without a `charset` parameter (a common default), the browser guesses
the encoding and falls back to Latin-1, so every non-ASCII character renders as
mojibake.

This affects any Aplos app using the default template with accented characters,
em dashes, or emoji. The `templates/minimal` starter reproduces it: its
`about.tsx` contains a U+2014 em dash that renders as `â€"`.

## Fix

Add `<meta charset="utf-8">` as the first element of `<head>`. It has to live in
the template rather than be injected by `InjectHeadTagsPlugin`, which appends
before `</head>` — the spec requires the declaration within the first 1024 bytes.

## Verification

Built `templates/minimal` and served `dist/` with a server that sends
`Content-type: text/html` and no charset:

- before: `file-based routing â€" this page lives at`
- after: `file-based routing — this page lives at`

Same server, same bytes on disk (`e2 80 94`, valid UTF-8) — only the meta tag
changed. `<meta charset>` lands at byte offset 33.