### PR TITLE
Enable side effects tree-shaking in client bundle

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -225,7 +225,6 @@ const frameworkConfig = {
         }
       : false,
     usedExports: !isDevelopment,
-    sideEffects: false,
   },
   output: {
     path: path.resolve(projectDirectory, outDir),

--- a/rspack.ssr.config.js
+++ b/rspack.ssr.config.js
@@ -75,6 +75,10 @@ const frameworkConfig = {
     minimize: false,
     splitChunks: false,
     usedExports: false,
+    // Kept off here (unlike the client config, where it is left at rspack's
+    // production default): this bundle is executed once by ssg.js to emit HTML,
+    // never shipped. Size is irrelevant, and eliding a side-effectful module —
+    // a CSS import, a polyfill — would silently change the rendered output.
     sideEffects: false,
   },
   module: {


### PR DESCRIPTION
`optimization.sideEffects: false` does not mean "these modules are side-effect
free, feel free to drop them". It disables the optimization entirely. Rspack's
production default is `true` (honour the `sideEffects` flag *and* analyse
unmarked modules); `'flag'` is the development default.

The client config set it to `false` right next to `usedExports: !isDevelopment`,
which suggests the intent was to optimize. The result was the opposite: no
side-effect based tree-shaking, and a degraded input to `concatenateModules`
(scope hoisting), which depends on `providedExports` + `usedExports`.

## Change

Drop the line from the client config so rspack applies its per-mode default.

The SSR config keeps `sideEffects: false`, now with a comment explaining why:
that bundle is executed once by `ssg.js` to emit HTML and is never shipped, so
size is irrelevant, while eliding a side-effectful module (a CSS import, a
polyfill) would silently change the rendered output.

## Impact

Built `templates/minimal` in production mode, cold cache:

| | before | after | delta |
|---|---|---|---|
| `vendors.js` | 536694 B | 429164 B | -107530 B |
| total JS | 556775 B | 449296 B | -107479 B (-19.3%) |
| total JS (gzip) | 164770 B | 131071 B | -33699 B (-20.5%) |

## Verification

- `bun test`: 49 pass
- `eslint`: clean
- `aplos build --static`: both routes pre-render, HTML contains the rendered React tree
- Served `dist/` and drove it in a browser: page renders, client-side routing to
  `/about` works, no console errors. The tree-shaken bundle executes correctly.