### PR TITLE
Fix production build with an empty public/, and head injection into inline scripts

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -187,6 +187,10 @@ if (!isDevelopment && fs.existsSync(userPublicDir)) {
           globOptions: {
             ignore: ["**/index.html"],
           },
+          // `public/` existing is not enough: the glob still has to match
+          // something. A directory that is empty, or whose only entry is the
+          // `index.html` ignored just above, makes the copy fail the build.
+          noErrorOnMissing: true,
         },
       ],
     })

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -144,7 +144,19 @@ class InjectHeadTagsPlugin {
             if (tags.length === 0) return;
 
             const headTags = tags.map(tag => `\n    ${tag}`).join('');
-            html = html.replace('</head>', `${headTags}\n  </head>`);
+
+            // Anchor on the LAST `</head>`, not the first. A template may carry
+            // an inline script holding that literal in a string, and injecting
+            // at the first match lands the tags inside the script: the head
+            // config is lost and the script body is corrupted. HtmlRspackPlugin
+            // normalizes the document, so the closing tag is always present and
+            // any literal occurrence necessarily precedes it.
+            const closeIndex = html.lastIndexOf('</head>');
+            if (closeIndex === -1) return;
+            html =
+              html.slice(0, closeIndex) +
+              `${headTags}\n  ` +
+              html.slice(closeIndex);
 
             // Hand rspack a real Source over UTF-8 bytes. A plain object literal
             // bypasses the asset pipeline, and `html.length` counts UTF-16 code


### PR DESCRIPTION
Two independent build defects, one commit each.

## 1. A `public/` with nothing to copy fails the build

The plugin was guarded by `fs.existsSync(userPublicDir)`, but existing is not
enough: `CopyRspackPlugin` also needs the glob to match at least one file. A
`public/` that is empty, or whose only entry is the `index.html` the pattern
explicitly ignores, aborts the production build with:

```
ERROR in × unable to locate '<project>/public/**/*' glob
```

Both are ordinary situations: `mkdir public` before putting assets in it, or a
`public/index.html` used to override the HTML template (a documented feature,
see `rspack.config.js` template resolution).

Fixed with `noErrorOnMissing: true`.

## 2. Head tags injected inside an inline script

`html.replace('</head>', ...)` anchors on the *first* occurrence. When the
template carries an inline script holding that literal in a string, the tags land
inside the script body:

```html
<script>window.SNIPPET="
    <title>app</title>
    <meta name="viewport" content="...">
  </head>"</script>
```

The `head` config is lost (it never reaches the real `<head>`) and the script is
corrupted. An inline analytics snippet or theme script is enough to trigger it.

Now anchored on the last `</head>`, which is necessarily the real closing tag:
`HtmlRspackPlugin` normalizes the document, so any literal occurrence precedes
it. A missing closing tag returns early instead of failing silently.

## Verification

Six generated projects, production build each:

| case | `public/` | result |
|---|---|---|
| A | one asset | builds, favicon copied |
| B | empty | was failing, now builds |
| C | absent | builds |
| D | only `index.html` | was failing, now builds, custom title preserved |
| E | template without `</head>` | builds (HtmlRspackPlugin normalizes it) |
| F | inline script containing `</head>` | was corrupted, now `window.SNIPPET="</head>"` intact |

Case F also checked through `aplos build --static`: the snippet survives in both
pre-rendered routes. `eslint` clean, `bun test` 49 pass.

Two things checked that turned out **not** to be bugs: minification keeps
`</head>`, and a template without a closing head tag still works because
HtmlRspackPlugin normalizes the document before this plugin sees it.