### PR TITLE
Fail the build when rspack exits non-zero or is killed by a signal

### DIFF
--- a/src/command/build.js
+++ b/src/command/build.js
@@ -89,9 +89,19 @@ export default async (options) => {
         console.log(`stderr: ${data.toString()}`);
     });
 
-    rspack.on('close', async (code) => {
-        if (code !== 0) {
-            console.log(`error: Process exited with code ${code}`);
+    // A failed bundle must fail the build: without an exit code, `bun run build`
+    // reports success and a deploy happily serves an empty output directory. A
+    // process killed by a signal (`SIGKILL` from the OOM killer, typically) reports
+    // a null code and names the signal instead, so neither can be read alone.
+    rspack.on('close', async (code, signal) => {
+        if (code !== 0 || signal !== null) {
+            console.log(
+                signal !== null
+                    ? `error: Process killed by ${signal} (out of memory?)`
+                    : `error: Process exited with code ${code}`,
+            );
+            process.exitCode = 1;
+
             return;
         }
 


### PR DESCRIPTION
`aplos build` logged a failed bundle and then exited 0, so `bun run build` reported success. A deploy would go on to serve an empty output directory: the app came up green with a blank page and no failing signal anywhere.

This surfaced on a Kemeter deploy where the container ran out of memory. The kernel killed rspack (`OOMKilled: true`, `Memory cgroup out of memory: Killed process (node)`), the build wrote no `dist/`, and Caddy served the missing directory while the deployment reported `running`.

A process killed by a signal reports a null exit code and names the signal instead, so neither can be read on its own, hence checking both. The SSG failure path a few lines below already sets `process.exitCode = 1`; this brings the bundle path in line with it.