### PR TITLE
Make the persistent build cache switchable, and drop production source maps

### DIFF
--- a/documentation/configuration/rspack.md
+++ b/documentation/configuration/rspack.md
@@ -87,5 +87,16 @@ bun run build
 
 The cache invalidates automatically when `rspack.config.js` or `rspack.ssr.config.js` changes. To force a clean build, delete the cache directory.
 
+### Memory cost
+
+The persistent cache trades memory for speed: restoring and serialising the module graph keeps it resident alongside the live one, which measured ~83 MB of extra peak RSS on an app whose bundle is under a megabyte. This is a known Rspack issue ([#11185](https://github.com/web-infra-dev/rspack/issues/11185)) and the overhead grows once a cache exists, so it hits hardest exactly where the cache is persisted across deploys.
+
+On a memory-capped builder that overhead can be enough to get the bundler OOM-killed — and a build that dies buys no warm builds at all. Set `APLOS_BUILD_CACHE=0` to trade warm builds for the lower peak:
+
+```bash
+# Build on a memory-constrained container
+APLOS_BUILD_CACHE=0 bun run build
+```
+
 !!! warning
     Avoid overriding core framework settings (entry, output.path, internal aliases) as this may break Aplos functionality.

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -225,10 +225,25 @@ if (fs.existsSync(userConfigPath) && userConfigPath !== __filename) {
   }
 }
 
+// The persistent cache is what a warm build is made of, so it stays on by default. It
+// is not free, though: serialising the module graph to disk keeps the live graph and
+// its serialisation buffer resident at once, which measured ~83 MB of peak RSS on an
+// app whose bundle is under a megabyte. On a memory-capped builder that overhead is
+// enough to get the bundler OOM-killed, and a build that dies buys no warm builds at
+// all — hence the escape hatch. Set APLOS_BUILD_CACHE=0 to trade warm builds for the
+// lower peak.
+const buildCacheEnabled = process.env.APLOS_BUILD_CACHE !== "0";
+
+// Production source maps emit megabytes of .map files that nothing fetches, so they are
+// off by default. Set APLOS_SOURCE_MAPS=1 to restore them, e.g. to feed an error monitor.
+const productionSourceMaps = process.env.APLOS_SOURCE_MAPS === "1";
+
 const frameworkConfig = {
   mode: isDevelopment ? "development" : "production",
-  devtool: isDevelopment ? "eval-source-map" : "hidden-source-map",
-  cache: {
+  devtool: isDevelopment
+    ? "eval-source-map"
+    : productionSourceMaps && "hidden-source-map",
+  cache: buildCacheEnabled && {
     type: "persistent",
     storage: {
       type: "filesystem",

--- a/rspack.ssr.config.js
+++ b/rspack.ssr.config.js
@@ -50,7 +50,9 @@ const frameworkConfig = {
   devtool: false,
   stats: "errors-warnings",
   infrastructureLogging: { level: "error" },
-  cache: {
+  // Same trade as the client compilation: on by default for warm builds, off via
+  // APLOS_BUILD_CACHE=0 when the builder cannot afford the serialisation overhead.
+  cache: process.env.APLOS_BUILD_CACHE !== "0" && {
     type: "persistent",
     storage: {
       type: "filesystem",


### PR DESCRIPTION
A production build of a client whose bundle is under a megabyte peaked at **402 MB** RSS and got OOM-killed on a memory-capped deploy container.

**The persistent cache accounts for ~91 MB of that.** Restoring and serialising the module graph keeps it resident alongside the live one. This is a known Rspack issue ([#11185](https://github.com/web-infra-dev/rspack/issues/11185)): +33% RSS on a cold cache, +94% once a cache exists, still open, and no config knob lowers it — the cache sub-options (`maxAge`, `maxVersions`, `readonly`, `snapshot`) do not touch the memory cost. The overhead therefore bites hardest exactly where the cache is persisted across deploys, which is the Kemeter setup we document.

The cache stays **on by default** — warm builds are the point of it. But a build that gets killed buys no warm builds at all, so `APLOS_BUILD_CACHE=0` now trades them for the lower peak:

| | peak RSS |
|---|---|
| default | 402 MB |
| `APLOS_BUILD_CACHE=0` | **311 MB** |

Production source maps are off by default in the same change: they emit 3.8 MB of `.map` files nothing fetches (`dist/` drops from 6 MB to 828 KB). They cost almost nothing in memory, so this is about shipped bytes, not the OOM. `APLOS_SOURCE_MAPS=1` restores them, e.g. to feed an error monitor.

Both compilations (client and SSR) honour the flag. Documented under Build cache → Memory cost.