### PR TITLE
Inject head tags after content hashing so the emitted HTML points at the real chunks

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -113,7 +113,15 @@ class InjectHeadTagsPlugin {
           // which rspack treats as stage 0. That ran the hook long before
           // HtmlRspackPlugin emits index.html at stage 700, so no .html asset
           // was ever found and the entire `head` config was silently dropped.
-          stage: compilation.constructor.PROCESS_ASSETS_STAGE_SUMMARIZE,
+          //
+          // REPORT (5000), not SUMMARIZE (1000): the content hashes are only
+          // substituted into the HTML at OPTIMIZE_HASH (2500). Replacing the asset
+          // with a RawSource before that froze the markup while its script tags still
+          // carried stale chunk names, so every hash in the emitted index.html —
+          // scripts and stylesheet alike — pointed at files the build never wrote.
+          // Production bundles could not load at all; dev was unaffected because its
+          // filenames carry no hash.
+          stage: compilation.constructor.PROCESS_ASSETS_STAGE_REPORT,
         },
         (assets, callback) => {
           const htmlFiles = Object.keys(assets).filter(file => file.endsWith('.html'));


### PR DESCRIPTION
Cherry-picked from `feat/lazy-routes` (135ae5a), where it was sitting behind the code-splitting work. It is a one-line fix and it is what production is currently broken on, so it should not wait for that branch.

`InjectHeadTagsPlugin` replaced the HTML asset at `PROCESS_ASSETS_STAGE_SUMMARIZE` (1000), but content hashes are only substituted into the markup at `OPTIMIZE_HASH` (2500). Freezing the asset before that point left the script and stylesheet tags carrying stale chunk names, so every hash in the emitted `index.html` pointed at a file the build never wrote. Moving the hook to `PROCESS_ASSETS_STAGE_REPORT` (5000) lets the substitution happen first.

Production bundles could not load at all; dev was unaffected because its filenames carry no hash — which is why this only ever showed up on a deploy.

Observed on a live Kemeter deploy, where `dist/` held `main.0b768daf.js` while `dist/index.html` asked for `main.09ea97fc.js`. The static server answered the missing files with its SPA fallback, so the browser got HTML where it expected JavaScript and the page stayed blank.

Verified against that app: all four referenced assets now resolve to files that exist.