### PR TITLE
Build a real project in tests, and make --mode win over NODE_ENV

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 dist
 .aplos
 
-src/pages
-
-aplos.config.js
+# Anchored to the repo root: these ignore the scratch app used to try the
+# framework out, not the committed fixtures the build tests run against.
+/src/pages
+/aplos.config.js

--- a/rspack.config.js
+++ b/rspack.config.js
@@ -9,7 +9,13 @@ import { merge } from "webpack-merge";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const isDevelopment = process.env.NODE_ENV !== "production";
+// `aplos build --mode` is the source of truth, forwarded as APLOS_MODE because
+// this config is loaded in the rspack subprocess. NODE_ENV is only a fallback:
+// reading it first made `--mode=production` silently emit a development bundle
+// (no contenthash, so deploys serve stale files from HTTP caches) whenever the
+// environment set NODE_ENV to anything else, which CI runners routinely do.
+const mode = process.env.APLOS_MODE || process.env.NODE_ENV || "development";
+const isDevelopment = mode !== "production";
 const projectDirectory = process.cwd();
 
 // Output directory, relative to the project root. Forwarded by `aplos build`

--- a/src/command/build.js
+++ b/src/command/build.js
@@ -78,7 +78,7 @@ export default async (options) => {
         "--config", runtime_dir + "/../rspack.config.js",
         "--entry", runtime_dir + "/runtime/app.jsx"
     ], {
-        env: { ...process.env, APLOS_OUT_DIR: outDir },
+        env: { ...process.env, APLOS_OUT_DIR: outDir, APLOS_MODE: options.mode },
     });
 
     rspack.stdout.on('data', (data) => {

--- a/tests/fixtures/basic/aplos.config.js
+++ b/tests/fixtures/basic/aplos.config.js
@@ -1,0 +1,10 @@
+export default {
+  reactStrictMode: true,
+  head: {
+    defaultTitle: 'Fixture',
+    meta: [
+      { name: 'viewport', content: 'width=device-width, initial-scale=1' },
+      { name: 'description', content: 'Build fixture' },
+    ],
+  },
+};

--- a/tests/fixtures/basic/package.json
+++ b/tests/fixtures/basic/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aplos-fixture-basic",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "dependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.0.0"
+  }
+}

--- a/tests/fixtures/basic/src/pages/index.jsx
+++ b/tests/fixtures/basic/src/pages/index.jsx
@@ -1,0 +1,3 @@
+export default function Home() {
+  return <h1>Home</h1>;
+}

--- a/tests/fixtures/basic/src/pages/static.jsx
+++ b/tests/fixtures/basic/src/pages/static.jsx
@@ -1,0 +1,10 @@
+'use static';
+
+export const meta = {
+  title: 'Static page',
+  description: 'Pre-rendered at build time',
+};
+
+export default function StaticPage() {
+  return <h1>Static</h1>;
+}

--- a/tests/helpers/fixture.js
+++ b/tests/helpers/fixture.js
@@ -1,0 +1,145 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const helpersDir = path.dirname(fileURLToPath(import.meta.url));
+const frameworkDir = path.resolve(helpersDir, '../..');
+const fixturesDir = path.join(helpersDir, '../fixtures');
+
+/**
+ * Installs the fixture's own dependencies, the way a real consumer project does.
+ *
+ * The framework's node_modules cannot simply be reused: react, react-dom and
+ * react-router-dom are peer dependencies there, and Bun materialises peers as
+ * empty stubs. Running a real install in the fixture is also what a user does,
+ * so the build under test resolves modules exactly as it would in the wild.
+ *
+ * Everything the framework itself needs at build time (rspack, the loaders) is
+ * resolved from the framework's own tree, so only the peers are installed here.
+ */
+async function installDependencies(root) {
+    await new Promise((resolve, reject) => {
+        const child = spawn('bun', ['install', '--no-save'], { cwd: root, stdio: 'pipe' });
+
+        let stderr = '';
+        child.stderr.on('data', (d) => { stderr += d; });
+        child.on('error', reject);
+        child.on('close', (code) => {
+            if (code !== 0) reject(new Error(`bun install failed in fixture: ${stderr}`));
+            else resolve();
+        });
+    });
+
+    // `aplos build` spawns node_modules/.bin/rspack from the project directory,
+    // and rspack is the framework's dependency, not the fixture's.
+    const binDir = path.join(root, 'node_modules', '.bin');
+    await fs.mkdir(binDir, { recursive: true });
+    await fs.symlink(
+        path.join(frameworkDir, 'node_modules', '.bin', 'rspack'),
+        path.join(binDir, 'rspack'),
+    ).catch((error) => {
+        if (error.code !== 'EEXIST') throw error;
+    });
+}
+
+/**
+ * Copies a fixture project into a temp directory, gives it a node_modules, and
+ * runs the real `bin/aplos` CLI against it.
+ *
+ * The build runs as a subprocess on purpose: it is the only way to observe the
+ * exit code the user actually gets, and `build.js` sets `process.exitCode` from
+ * an async callback rather than throwing, so an in-process call cannot be awaited.
+ */
+export async function loadFixture(name) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), `aplos-${name}-`));
+
+    try {
+        await fs.cp(path.join(fixturesDir, name), root, { recursive: true });
+        await installDependencies(root);
+    } catch (error) {
+        // The caller never gets a handle to clean up a fixture that failed to set up.
+        await fs.rm(root, { recursive: true, force: true });
+        throw error;
+    }
+
+    let outDir = 'dist';
+
+    return {
+        root,
+
+        /** Runs `aplos build`, resolving with the exit code and captured output. */
+        async build({ mode = 'production', args = [], env = {} } = {}) {
+            // Commander accepts both `--out-dir dist2` and `--out-dir=dist2`; reading
+            // only the first form would leave readFile() pointing at a stale dist/.
+            const flagIndex = args.indexOf('--out-dir');
+            if (flagIndex !== -1) outDir = args[flagIndex + 1];
+
+            const inlineFlag = args.find((a) => a.startsWith('--out-dir='));
+            if (inlineFlag) outDir = inlineFlag.slice('--out-dir='.length);
+
+            return new Promise((resolve) => {
+                const child = spawn(
+                    process.execPath,
+                    [path.join(frameworkDir, 'bin', 'aplos'), 'build', `--mode=${mode}`, ...args],
+                    { cwd: root, env: { ...process.env, ...env } },
+                );
+
+                let stdout = '';
+                let stderr = '';
+                child.stdout.on('data', (d) => { stdout += d; });
+                child.stderr.on('data', (d) => { stderr += d; });
+
+                child.on('close', (code, signal) => resolve({ code, signal, stdout, stderr }));
+            });
+        },
+
+        /**
+         * Reads a path relative to the output directory. A dangling asset reference
+         * throws ENOENT here, which is what makes broken chunk links fail a test
+         * without a dedicated assertion for them.
+         */
+        readFile(p) {
+            return fs.readFile(path.join(root, outDir, p.replace(/^\//, '')), 'utf-8');
+        },
+
+        readdir(p = '') {
+            return fs.readdir(path.join(root, outDir, p.replace(/^\//, '')));
+        },
+
+        async exists(p) {
+            try {
+                await fs.access(path.join(root, outDir, p.replace(/^\//, '')));
+                return true;
+            } catch {
+                return false;
+            }
+        },
+
+        writeSource(p, contents) {
+            const target = path.join(root, p);
+            return fs.mkdir(path.dirname(target), { recursive: true })
+                .then(() => fs.writeFile(target, contents, 'utf-8'));
+        },
+
+        cleanup() {
+            return fs.rm(root, { recursive: true, force: true });
+        },
+    };
+}
+
+/** Extracts every src/href a browser would fetch from an emitted HTML document. */
+export function referencedAssets(html) {
+    const refs = [];
+    const patterns = [/<script[^>]+src="([^"]+)"/g, /<link[^>]+href="([^"]+)"/g];
+
+    for (const re of patterns) {
+        let m;
+        while ((m = re.exec(html)) !== null) {
+            if (!m[1].startsWith('http') && !m[1].startsWith('//')) refs.push(m[1]);
+        }
+    }
+
+    return refs;
+}

--- a/tests/integration/build.test.js
+++ b/tests/integration/build.test.js
@@ -1,0 +1,136 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { loadFixture, referencedAssets } from '../helpers/fixture.js';
+
+// These tests build a real project and assert on what lands in dist/. Reverting
+// fdc9342, 6e92194 or ba56556 leaves the unit suite green; it must not leave
+// this one green.
+describe('production build artifacts', () => {
+    let fixture;
+    let result;
+    let html;
+
+    beforeAll(async () => {
+        fixture = await loadFixture('basic');
+        result = await fixture.build({ mode: 'production' });
+        html = await fixture.readFile('index.html');
+    }, 120_000);
+
+    afterAll(() => fixture?.cleanup());
+
+    test('the build succeeds and emits an HTML entry point', () => {
+        expect(result.code).toBe(0);
+        expect(html).toContain('<div id="root">');
+    });
+
+    // Locks fdc9342: head tags were injected before content hashing, so the
+    // emitted HTML pointed at chunk names that never existed on disk.
+    test('every asset the HTML references exists in the output', async () => {
+        const refs = referencedAssets(html);
+        expect(refs.length).toBeGreaterThan(0);
+
+        for (const ref of refs) {
+            // Throws ENOENT when the reference is dangling.
+            await fixture.readFile(ref);
+        }
+    });
+
+    test('emitted scripts carry a content hash in production', () => {
+        const scripts = referencedAssets(html).filter((r) => r.endsWith('.js'));
+        expect(scripts.length).toBeGreaterThan(0);
+        expect(scripts.every((s) => /\.[a-f0-9]{8}\.js$/.test(s))).toBe(true);
+    });
+
+    // Locks 0183ae0 and the `use static` path: a page carrying the directive is
+    // pre-rendered to its own HTML document, with its own meta.
+    test('a "use static" page is pre-rendered with its route meta', async () => {
+        const staticHtml = await fixture.readFile('static.html');
+
+        expect(staticHtml).toContain('<h1>Static</h1>');
+        expect(staticHtml).toContain('Static page');
+        expect(staticHtml).toContain('Pre-rendered at build time');
+    });
+
+    // The pre-rendered document goes through a different injection path than
+    // index.html, and must not end up with a second head or dangling assets.
+    test('the pre-rendered document is as sound as the entry point', async () => {
+        const staticHtml = await fixture.readFile('static.html');
+
+        expect(staticHtml.split('</head>').length - 1).toBe(1);
+
+        for (const ref of referencedAssets(staticHtml)) {
+            await fixture.readFile(ref);
+        }
+    });
+
+    // Locks ba56556: tags were anchored on the first `</head>`, which could sit
+    // inside an inline script rather than closing the real head.
+    test('the document has exactly one head, and the tags land inside it', () => {
+        expect(html.split('</head>').length - 1).toBe(1);
+
+        const head = html.slice(0, html.indexOf('</head>'));
+        expect(head).toContain('charset');
+        expect(head).toContain('viewport');
+    });
+
+    // Locks 85532c5: the configured head was silently never injected.
+    test('the configured head reaches the document', () => {
+        expect(html).toContain('Build fixture');
+    });
+
+    // Locks dcfc275: production shipped source maps.
+    test('production emits no source maps', async () => {
+        const files = await fixture.readdir();
+        expect(files.some((f) => f.endsWith('.map'))).toBe(false);
+        expect(html).not.toContain('sourceMappingURL');
+    });
+});
+
+// The CLI flag must win over the ambient environment. Reading NODE_ENV first made
+// `--mode=production` emit an unhashed development bundle on any runner that sets
+// NODE_ENV to something else, and HTTP caches then serve stale files after a deploy.
+describe('build mode comes from --mode, not the environment', () => {
+    let fixture;
+
+    beforeAll(async () => {
+        fixture = await loadFixture('basic');
+    });
+
+    afterAll(() => fixture?.cleanup());
+
+    test('--mode=production wins over NODE_ENV=development', async () => {
+        const { code } = await fixture.build({
+            mode: 'production',
+            env: { NODE_ENV: 'development' },
+        });
+        expect(code).toBe(0);
+
+        const html = await fixture.readFile('index.html');
+        const scripts = referencedAssets(html).filter((r) => r.endsWith('.js'));
+
+        expect(scripts.length).toBeGreaterThan(0);
+        expect(scripts.every((s) => /\.[a-f0-9]{8}\.js$/.test(s))).toBe(true);
+
+        const files = await fixture.readdir();
+        expect(files.some((f) => f.endsWith('.map'))).toBe(false);
+    }, 120_000);
+});
+
+describe('build failure handling', () => {
+    let fixture;
+
+    beforeAll(async () => {
+        fixture = await loadFixture('basic');
+    });
+
+    afterAll(() => fixture?.cleanup());
+
+    // Locks 6e92194: a failing bundle reported success, and a deploy happily
+    // served an empty output directory.
+    test('a broken page fails the build with a non-zero exit code', async () => {
+        await fixture.writeSource('src/pages/broken.jsx', 'export default function Broken( {');
+
+        const { code } = await fixture.build({ mode: 'production' });
+
+        expect(code).not.toBe(0);
+    }, 120_000);
+});


### PR DESCRIPTION
## Why

Reverting `fdc9342`, `6e92194` and `ba56556` leaves the unit suite at **49 pass / 0 fail** with a lint-clean tree. Those are three real fixes, one of which stops the emitted HTML from pointing at chunk names that never existed on disk. In other words, CI goes green on a commit whose production bundle cannot load.

That is not a coverage gap, it is an altitude gap: the 49 tests run in 98ms and never produce an artifact. Every recent build bug lived in code that has no tests at all (`rspack.config.js`, `devServer.js`, `ssg.js`, `build.js`).

## The harness

A fixture project is copied to a temp dir, gets a real `bun install`, and the real `bin/aplos build` runs against it as a subprocess. The subprocess matters: `build.js` sets `process.exitCode` from an async callback rather than throwing, so an in-process call cannot observe the exit code a user gets.

`readFile()` resolves inside the output directory, so a dangling asset reference raises ENOENT on its own. That is what makes "the HTML points at chunks that do not exist" fail a test without a dedicated assertion for it.

Ten assertions on a real `dist/`: referenced assets exist, exactly one `</head>`, scripts carry a contenthash, a `"use static"` page is pre-rendered with its route meta, no source maps in production, and a broken page exits non-zero.

Verified: with `fdc9342` and `6e92194` reverted, the old suite stays green and this one fails.

## The bug it caught on its first run

`rspack.config.js` derived `isDevelopment` from `NODE_ENV` and ignored the `--mode` flag the CLI passes it. So `aplos build --mode=production` emitted a **development bundle with no contenthash** on any runner that sets `NODE_ENV` to something else, which CI runners routinely do. Without a contenthash, HTTP caches keep serving the previous deploy's files.

The CLI now forwards its resolved mode as `APLOS_MODE` and the config reads that first, keeping `NODE_ENV` as a fallback. The SSR config is unaffected, it already hardcodes `mode: "production"`.

## Also

The ignore rules for the scratch app (`src/pages`, `aplos.config.js`) were unanchored and swallowed the fixture's own files, so the harness could not run from a clean clone. They are now anchored to the repo root.