### PR TITLE
Resolve the rspack binary through the module graph, not a guessed path

### DIFF
--- a/src/build/rspack-bin.js
+++ b/src/build/rspack-bin.js
@@ -1,0 +1,40 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Resolves the rspack CLI entry point through Node's module resolution.
+ *
+ * Guessing `<project>/node_modules/.bin/rspack` only works when the installer
+ * hoists a flat node_modules next to the user's project. It breaks under Yarn
+ * PnP (no node_modules at all), under pnpm's isolated linker, and in monorepos
+ * where the framework is not a top-level dependency. Resolving from this module
+ * instead means the lookup starts inside the framework, where `@rspack/cli` is a
+ * direct dependency, and Node applies whatever strategy the installer uses.
+ *
+ * The package only exports `.` and `./package.json`, so the bin path cannot be
+ * required directly; it is read from the manifest.
+ */
+export function resolveRspackBin() {
+    const manifestPath = require.resolve('@rspack/cli/package.json');
+    const manifest = require('@rspack/cli/package.json');
+
+    const bin = typeof manifest.bin === 'string' ? manifest.bin : manifest.bin?.rspack;
+    if (!bin) {
+        throw new Error('Could not find the rspack binary in @rspack/cli. Is the install complete?');
+    }
+
+    return path.resolve(path.dirname(manifestPath), bin);
+}
+
+/**
+ * Arguments for spawning the CLI through the current Node binary.
+ *
+ * Running the bin file directly relies on its executable bit and shebang, which
+ * a package manager may not reproduce (and Windows never does). Invoking it with
+ * `process.execPath` also guarantees the child runs the same Node as the parent.
+ */
+export function rspackCommand(args) {
+    return [process.execPath, [resolveRspackBin(), ...args]];
+}

--- a/src/build/ssg.js
+++ b/src/build/ssg.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { spawn } from 'child_process';
 import { pathToFileURL, fileURLToPath } from 'url';
+import { rspackCommand } from './rspack-bin.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -17,16 +18,17 @@ function outputHtmlPath(distDir, routePath) {
     return path.join(distDir, `${trimmed}.html`);
 }
 
-async function buildSSRBundle(projectDirectory, frameworkDirectory, mode) {
+async function buildSSRBundle(frameworkDirectory, mode) {
     const ssrConfigPath = path.resolve(frameworkDirectory, 'rspack.ssr.config.js');
-    const rspackBin = path.join(projectDirectory, 'node_modules', '.bin', 'rspack');
+
+    const [command, commandArgs] = rspackCommand([
+        '--mode=' + mode,
+        '--config', ssrConfigPath,
+        '--entry', SSR_ENTRY,
+    ]);
 
     return new Promise((resolve, reject) => {
-        const child = spawn(rspackBin, [
-            '--mode=' + mode,
-            '--config', ssrConfigPath,
-            '--entry', SSR_ENTRY,
-        ], {
+        const child = spawn(command, commandArgs, {
             env: { ...process.env, APLOS_SSR: '1' },
         });
 
@@ -70,7 +72,7 @@ export default async function ssg({ mode, forceAll = false, outDir } = {}) {
     }
 
     console.log('\n  Building SSR bundle...');
-    await buildSSRBundle(projectDirectory, frameworkDirectory, mode || 'production');
+    await buildSSRBundle(frameworkDirectory, mode || 'production');
 
     const ssrBundlePath = path.join(cacheDir, SSR_BUNDLE_NAME);
     if (!fs.existsSync(ssrBundlePath)) {

--- a/src/command/build.js
+++ b/src/command/build.js
@@ -2,6 +2,7 @@ import {spawn} from "child_process";
 import {buildRouter}  from "../build/router.js";
 import get_config from '../build/config.js';
 import ssg from '../build/ssg.js';
+import { rspackCommand } from '../build/rspack-bin.js';
 import { fileURLToPath } from 'url';
 import path from 'path';
 
@@ -63,7 +64,6 @@ const showBundleAnalysis = (projectDirectory, outDir = 'dist') => {
 export default async (options) => {
     let projectDirectory = process.cwd();
     let runtime_dir = __dirname + "/..";
-    let node_modules = projectDirectory + "/node_modules";
 
     // Output directory precedence: explicit --out-dir wins, then $APLOS_OUT_DIR,
     // then the `dist` default. The resolved value is forwarded to the rspack
@@ -73,11 +73,13 @@ export default async (options) => {
     const buildStart = performance.now();
     await buildRouter(await get_config(projectDirectory));
 
-    const rspack = spawn(node_modules + "/.bin/rspack", [
+    const [command, commandArgs] = rspackCommand([
         "--mode=" + options.mode,
         "--config", runtime_dir + "/../rspack.config.js",
         "--entry", runtime_dir + "/runtime/app.jsx"
-    ], {
+    ]);
+
+    const rspack = spawn(command, commandArgs, {
         env: { ...process.env, APLOS_OUT_DIR: outDir, APLOS_MODE: options.mode },
     });
 

--- a/tests/helpers/fixture.js
+++ b/tests/helpers/fixture.js
@@ -32,16 +32,11 @@ async function installDependencies(root) {
         });
     });
 
-    // `aplos build` spawns node_modules/.bin/rspack from the project directory,
-    // and rspack is the framework's dependency, not the fixture's.
-    const binDir = path.join(root, 'node_modules', '.bin');
-    await fs.mkdir(binDir, { recursive: true });
-    await fs.symlink(
-        path.join(frameworkDir, 'node_modules', '.bin', 'rspack'),
-        path.join(binDir, 'rspack'),
-    ).catch((error) => {
-        if (error.code !== 'EEXIST') throw error;
-    });
+    // Deliberately no node_modules/.bin/rspack here. npm does not create it for a
+    // project consuming aplosjs, since @rspack/cli is the framework's dependency
+    // rather than the project's. The build must resolve rspack through its own
+    // module graph, so leaving the bin out is what keeps that honest: restore the
+    // old `spawn(<project>/node_modules/.bin/rspack)` and these tests fail.
 }
 
 /**

--- a/tests/integration/rspack-bin.test.js
+++ b/tests/integration/rspack-bin.test.js
@@ -1,0 +1,35 @@
+import { describe, test, expect } from 'bun:test';
+import { existsSync } from 'node:fs';
+import { resolveRspackBin, rspackCommand } from '../../src/build/rspack-bin.js';
+
+// The build used to spawn `<project>/node_modules/.bin/rspack`. That bin is only
+// there when the installer hoists it next to the user's project, which npm does
+// not do for a dependency of aplosjs rather than of the project. Resolving from
+// the framework's own module graph is what makes the build work under npm, Yarn
+// PnP and pnpm's isolated linker, not just Bun.
+describe('rspack binary resolution', () => {
+    test('resolves to a file that exists', () => {
+        const bin = resolveRspackBin();
+
+        expect(existsSync(bin)).toBe(true);
+    });
+
+    test('resolves through the framework, not the project directory', () => {
+        const bin = resolveRspackBin();
+
+        // A path under the consuming project's node_modules/.bin would break the
+        // moment the installer stops hoisting.
+        expect(bin).not.toContain(`${'node_modules'}/.bin/`);
+        expect(bin).toContain('@rspack/cli');
+    });
+
+    test('runs the CLI through the current node binary', () => {
+        const [command, args] = rspackCommand(['--mode=production']);
+
+        // Executing the bin file directly relies on its executable bit and shebang,
+        // which the installer is not required to reproduce.
+        expect(command).toBe(process.execPath);
+        expect(args[0]).toBe(resolveRspackBin());
+        expect(args).toContain('--mode=production');
+    });
+});


### PR DESCRIPTION
## The bug

`aplos build` spawned `<project>/node_modules/.bin/rspack`, a path it guessed rather than resolved.

That bin only exists when the installer hoists it next to the user's project. **npm does not**, because `@rspack/cli` is a dependency of `aplosjs`, not of the project consuming it. Verified on a real consumer project:

```
$ npm install aplosjs
$ ls node_modules/.bin/rspack
# absent
$ node node_modules/aplosjs/bin/aplos build --mode=production
# ENOENT
```

The same applies to pnpm's isolated linker, Yarn PnP (no `node_modules` at all), and monorepo layouts where the framework is not top-level. Bun's flat `node_modules` is what has been hiding this.

## The fix

Resolution starts from the framework's own module, where `@rspack/cli` is a direct dependency, so Node applies whatever strategy the installer uses. `@rspack/cli` only exports `.` and `./package.json`, so the bin path is read from the manifest rather than required directly.

The CLI now runs through `process.execPath` rather than executing the bin file, which does not depend on an executable bit or a shebang the installer is not required to reproduce (and Windows never does).

Both call sites share one module, rather than duplicating the resolution.

## Verified end to end

A project that installs `aplosjs` with **npm** and builds with **node** now emits hashed bundles and pre-renders its static routes:

```
dist/index.html  dist/main.17e615ac.js  dist/static.html  dist/vendors.8186f9cf.js
```

## The test actually locks it

The fixture deliberately has **no** `node_modules/.bin/rspack`, mirroring what npm produces. Restoring the old `spawn(<project>/node_modules/.bin/rspack)` fails the integration suite. Without that, the fixture would have carried a crutch that hides the very bug being fixed.