### PR TITLE
Give the <head> a single owner

### DIFF
--- a/rspack.config.js
+++ b/rspack.config.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from "url";
 import fs from "fs";
 import { pathToFileURL } from "url";
 import { merge } from "webpack-merge";
+import { toHeadElements, renderHead } from "./src/build/head.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -63,39 +64,6 @@ if (fs.existsSync(configPath)) {
   }
 }
 
-// Escape a value interpolated into a double-quoted HTML attribute. Without this,
-// a `"` in a config value (say a `description` containing a quotation) closes the
-// attribute early and the rest of the value is parsed as markup.
-// `&` goes first, otherwise it would re-escape the entities introduced below.
-function escapeAttribute(value) {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-// Escape text content. `<title>` holds character data, so quotes are fine but
-// angle brackets and ampersands are not.
-function escapeText(value) {
-  return String(value)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-// Serialize a tag's attributes. A `true` boolean renders as a bare attribute
-// (`async`), `false` and `null`/`undefined` drop the attribute entirely.
-function renderAttributes(attrs) {
-  return Object.entries(attrs)
-    .map(([key, value]) => {
-      if (value === true) return key;
-      if (value === false || value == null) return "";
-      return `${key}="${escapeAttribute(value)}"`;
-    })
-    .filter(Boolean)
-    .join(" ");
-}
 
 // Custom plugin to inject head tags.
 //
@@ -136,28 +104,12 @@ class InjectHeadTagsPlugin {
             const asset = assets[filename];
             let html = asset.source().toString();
 
-            const tags = [];
+            // Shared with the SSG, so both paths escape identically and neither
+            // can grow its own idea of what a head tag is.
+            const elements = toHeadElements(this.headConfig);
+            if (elements.length === 0) return;
 
-            // Title first, so it stays at the top of <head>.
-            if (this.headConfig.defaultTitle) {
-              tags.push(`<title>${escapeText(this.headConfig.defaultTitle)}</title>`);
-            }
-
-            for (const meta of this.headConfig.meta || []) {
-              tags.push(`<meta ${renderAttributes(meta)}>`);
-            }
-
-            for (const link of this.headConfig.link || []) {
-              tags.push(`<link ${renderAttributes(link)}>`);
-            }
-
-            for (const script of this.headConfig.script || []) {
-              tags.push(`<script ${renderAttributes(script)}></script>`);
-            }
-
-            if (tags.length === 0) return;
-
-            const headTags = tags.map(tag => `\n    ${tag}`).join('');
+            const headTags = `\n${renderHead(elements)}`;
 
             // Anchor on the LAST `</head>`, not the first. A template may carry
             // an inline script holding that literal in a string, and injecting

--- a/src/build/head.js
+++ b/src/build/head.js
@@ -1,0 +1,148 @@
+// The single owner of everything that goes inside <head>.
+//
+// This used to be two independent implementations: a plugin rewriting the emitted
+// HTML in rspack.config.js, and injectMetaTags() rewriting it again in ssg.js.
+// They disagreed on where the head ends (last vs first `</head>`), on how to
+// escape, and on what a tag even is, which is why the same class of bug was found
+// and fixed three times (85532c5, ba56556, fdc9342) and still lived on in the SSG
+// path. Both now build the same descriptors and go through the same serializer.
+
+// A tag is described, never spelled out as a string, so it can be merged by
+// identity and escaped in exactly one place.
+const IDENTITY = {
+    title: () => 'title',
+    meta: (attrs) => {
+        if (attrs.name) return `meta:name=${attrs.name}`;
+        if (attrs.property) return `meta:property=${attrs.property}`;
+        if (attrs.httpEquiv || attrs['http-equiv']) {
+            return `meta:http-equiv=${attrs.httpEquiv || attrs['http-equiv']}`;
+        }
+        if (attrs.charset) return 'meta:charset';
+        return null;
+    },
+    link: (attrs) => (attrs.rel === 'canonical' ? 'link:rel=canonical' : null),
+};
+
+// HTML attribute names, per the spec's sane subset. Anything else would let a key
+// carrying `>` or a quote close the tag and inject markup: the values were escaped
+// here, but the keys never were, and og/twitter keys can come straight from a CMS.
+const VALID_ATTRIBUTE_NAME = /^[A-Za-z][A-Za-z0-9:_.-]*$/;
+
+/** Escapes character data. `<title>` holds text, so quotes are fine, brackets are not. */
+export function escapeText(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+/** Escapes an attribute value, which sits inside double quotes. */
+export function escapeAttribute(value) {
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+/**
+ * Turns an aplos `head` config, or a page's `meta` export, into tag descriptors.
+ * Both shapes are accepted so the client build and the SSG describe head the same way.
+ */
+export function toHeadElements(config = {}) {
+    const elements = [];
+
+    const title = config.title || config.defaultTitle;
+    if (title) elements.push({ tag: 'title', children: String(title) });
+
+    if (config.description) {
+        elements.push({ tag: 'meta', attrs: { name: 'description', content: config.description } });
+    }
+
+    if (config.canonical) {
+        elements.push({ tag: 'link', attrs: { rel: 'canonical', href: config.canonical } });
+    }
+
+    if (Array.isArray(config.keywords) && config.keywords.length > 0) {
+        elements.push({ tag: 'meta', attrs: { name: 'keywords', content: config.keywords.join(', ') } });
+    }
+
+    for (const [key, content] of Object.entries(config.og || {})) {
+        elements.push({ tag: 'meta', attrs: { property: `og:${key}`, content } });
+    }
+
+    for (const [key, content] of Object.entries(config.twitter || {})) {
+        elements.push({ tag: 'meta', attrs: { name: `twitter:${key}`, content } });
+    }
+
+    for (const attrs of config.meta || []) {
+        if (attrs && typeof attrs === 'object') elements.push({ tag: 'meta', attrs });
+    }
+
+    for (const attrs of config.link || []) {
+        if (attrs && typeof attrs === 'object') elements.push({ tag: 'link', attrs });
+    }
+
+    for (const attrs of config.script || []) {
+        if (attrs && typeof attrs === 'object') elements.push({ tag: 'script', attrs, children: '' });
+    }
+
+    return elements;
+}
+
+/**
+ * Merges page-level tags over global ones.
+ *
+ * Tags that can only appear once (the title, a given meta name, the canonical
+ * link) are keyed by identity and the page wins. Everything else accumulates.
+ * Without this, a page that sets its own description shipped two of them.
+ */
+export function mergeHead(globalElements = [], routeElements = []) {
+    const merged = [];
+    const byIdentity = new Map();
+
+    for (const element of [...globalElements, ...routeElements]) {
+        const identify = IDENTITY[element.tag];
+        const key = identify ? identify(element.attrs || {}) : null;
+
+        if (key === null || key === undefined) {
+            merged.push(element);
+            continue;
+        }
+
+        if (byIdentity.has(key)) {
+            merged[byIdentity.get(key)] = element;
+        } else {
+            byIdentity.set(key, merged.length);
+            merged.push(element);
+        }
+    }
+
+    return merged;
+}
+
+/** Serializes one tag. The only place a head tag becomes a string. */
+function renderElement({ tag, attrs = {}, children }) {
+    const rendered = Object.entries(attrs)
+        .filter(([name, value]) => {
+            if (value === false || value === null || value === undefined) return false;
+            // A key that cannot be a valid attribute name is dropped rather than
+            // written out, where it could close the tag and inject markup.
+            return VALID_ATTRIBUTE_NAME.test(name);
+        })
+        .map(([name, value]) => (value === true ? name : `${name}="${escapeAttribute(value)}"`))
+        .join(' ');
+
+    const open = rendered ? `<${tag} ${rendered}>` : `<${tag}>`;
+
+    if (children === undefined) return open;
+
+    return `${open}${escapeText(children)}</${tag}>`;
+}
+
+/** Serializes head tags, ready to be placed inside <head>. */
+export function renderHead(elements, indent = '    ') {
+    return elements
+        .map((element) => `${indent}${renderElement(element)}`)
+        .join('\n');
+}

--- a/src/build/ssg.js
+++ b/src/build/ssg.js
@@ -3,6 +3,7 @@ import path from 'path';
 import { spawn } from 'child_process';
 import { pathToFileURL, fileURLToPath } from 'url';
 import { rspackCommand } from './rspack-bin.js';
+import { toHeadElements, renderHead } from './head.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -120,81 +121,118 @@ export default async function ssg({ mode, forceAll = false, outDir } = {}) {
     console.log(`  Pre-rendered ${rendered}/${staticRoutes.length} route(s).`);
 }
 
-function escapeHtml(value) {
-    return String(value)
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-        .replace(/"/g, '&quot;');
-}
-
-function metaTag(attrs) {
-    const parts = Object.entries(attrs)
-        .filter(([, v]) => v !== undefined && v !== null && v !== false)
-        .map(([k, v]) => `${k}="${escapeHtml(v)}"`);
-    return `<meta ${parts.join(' ')}>`;
-}
-
-function buildMetaHtml(meta) {
-    const tags = [];
-    if (meta.title) {
-        tags.push(`<title>${escapeHtml(meta.title)}</title>`);
-    }
-    if (meta.description) {
-        tags.push(metaTag({ name: 'description', content: meta.description }));
-    }
-    if (meta.canonical) {
-        tags.push(`<link rel="canonical" href="${escapeHtml(meta.canonical)}">`);
-    }
-    if (Array.isArray(meta.keywords) && meta.keywords.length > 0) {
-        tags.push(metaTag({ name: 'keywords', content: meta.keywords.join(', ') }));
-    }
-    if (meta.og && typeof meta.og === 'object') {
-        for (const [key, value] of Object.entries(meta.og)) {
-            tags.push(metaTag({ property: `og:${key}`, content: value }));
-        }
-    }
-    if (meta.twitter && typeof meta.twitter === 'object') {
-        for (const [key, value] of Object.entries(meta.twitter)) {
-            tags.push(metaTag({ name: `twitter:${key}`, content: value }));
-        }
-    }
-    if (Array.isArray(meta.meta)) {
-        for (const entry of meta.meta) {
-            if (entry && typeof entry === 'object') {
-                tags.push(metaTag(entry));
-            }
-        }
-    }
-    if (Array.isArray(meta.link)) {
-        for (const entry of meta.link) {
-            if (entry && typeof entry === 'object') {
-                const parts = Object.entries(entry)
-                    .filter(([, v]) => v !== undefined && v !== null && v !== false)
-                    .map(([k, v]) => `${k}="${escapeHtml(v)}"`);
-                tags.push(`<link ${parts.join(' ')}>`);
-            }
-        }
-    }
-    return tags.join('\n    ');
-}
-
+/**
+ * Layers a route's meta over the head already present in the document.
+ *
+ * The template arrives with the global head config already injected by the build,
+ * so a route's title and description must REPLACE their global counterparts, not
+ * queue up behind them: appending sent two <title> and two meta descriptions to
+ * crawlers. Tags are parsed back into descriptors, merged by identity, and the
+ * head is rewritten once through the shared serializer.
+ *
+ * Anchoring is on the LAST `</head>`, matching the build plugin. The old code
+ * replaced the FIRST one, which lands the tags inside an inline script that
+ * merely contains the literal, and drops them from the head entirely.
+ */
 export function injectMetaTags(html, meta) {
-    const block = buildMetaHtml(meta);
-    if (!block) {
+    const routeElements = toHeadElements(meta || {});
+    if (routeElements.length === 0) {
         return html;
     }
-    const titleMatch = block.match(/<title>[\s\S]*?<\/title>/);
-    if (titleMatch) {
-        if (/<title>[\s\S]*?<\/title>/.test(html)) {
-            html = html.replace(/<title>[\s\S]*?<\/title>/, titleMatch[0]);
-        } else {
-            html = html.replace('</head>', `    ${titleMatch[0]}\n  </head>`);
-        }
+
+    // Anchor on the LAST `</head>`, as the build plugin does. Replacing the first
+    // one lands the tags inside an inline script that merely contains the literal.
+    const closeIndex = html.lastIndexOf('</head>');
+    if (closeIndex === -1) {
+        return html;
     }
-    const remaining = block.replace(/<title>[\s\S]*?<\/title>\s*/, '');
-    if (remaining) {
-        html = html.replace('</head>', `    ${remaining}\n  </head>`);
+
+    // Only the tags this route actually overrides are removed. The rest of the
+    // head is left byte for byte: re-serializing it would mean parsing inline
+    // scripts and stylesheets back out of markup, which is how this file grew a
+    // bug in the first place.
+    let head = html.slice(0, closeIndex);
+    const tail = html.slice(closeIndex);
+
+    for (const element of routeElements) {
+        head = removeTag(head, element);
     }
-    return html;
+
+    return `${head}${renderHead(routeElements)}\n  ${tail}`;
+}
+
+/**
+ * Strips the tag a route element is about to replace, so the page's title and
+ * description supersede the global ones instead of queueing up behind them.
+ * Appending sent two <title> and two meta descriptions to crawlers.
+ *
+ * Only self-identifying tags are matched: a title, a named or property meta, a
+ * canonical link. Anything else accumulates, which is the correct behaviour for
+ * stylesheets, preloads and scripts.
+ */
+function removeTag(head, element) {
+    const { tag, attrs = {} } = element;
+
+    let pattern;
+
+    // The patterns match the tag alone. Leading whitespace is deliberately left
+    // out: masked-out regions are blanked to spaces of the same length, so a
+    // pattern that could start on whitespace would anchor inside one of them.
+    if (tag === 'title') {
+        pattern = /<title>[\s\S]*?<\/title>/i;
+    } else if (tag === 'meta') {
+        const name = attrs.name || attrs.property;
+        if (!name) return head;
+
+        const key = attrs.name ? 'name' : 'property';
+        // The attribute may be quoted either way and carry others alongside it.
+        pattern = new RegExp(
+            `<meta[^>]*\\b${key}=["']${escapeForRegExp(name)}["'][^>]*>`,
+            'i',
+        );
+    } else if (tag === 'link' && attrs.rel === 'canonical') {
+        pattern = /<link[^>]*\brel=["']canonical["'][^>]*>/i;
+    } else {
+        return head;
+    }
+
+    return replaceOutsideInertRegions(head, pattern);
+}
+
+/**
+ * Applies a replacement only to live markup.
+ *
+ * A tag pattern will happily match inside an HTML comment or a script body, where
+ * the text merely looks like markup. Stripping the "tag" there leaves the real one
+ * in place (so the page ships two descriptions) and corrupts the comment or the
+ * script. Inert regions are masked out before the match and restored after.
+ */
+function replaceOutsideInertRegions(html, pattern) {
+    const inert = [];
+    const masked = html.replace(
+        /<!--[\s\S]*?-->|<script\b[^>]*>[\s\S]*?<\/script>/gi,
+        (region) => {
+            const token = ` ${inert.length} `;
+            inert.push(region);
+            return token.padEnd(region.length, ' ').slice(0, region.length);
+        },
+    );
+
+    const match = pattern.exec(masked);
+    if (!match) return html;
+
+    // The mask preserves offsets, so the index maps straight back onto the source.
+    let start = match.index;
+    let end = start + match[0].length;
+
+    // Take the tag's own indentation and trailing newline with it, so removing a
+    // tag does not leave a blank line where it stood.
+    while (start > 0 && (html[start - 1] === ' ' || html[start - 1] === '\t')) start--;
+    if (html[end] === '\n') end++;
+
+    return html.slice(0, start) + html.slice(end);
+}
+
+function escapeForRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }

--- a/tests/build/head.test.js
+++ b/tests/build/head.test.js
@@ -1,0 +1,93 @@
+import { describe, test, expect } from 'bun:test';
+import { toHeadElements, mergeHead, renderHead } from '../../src/build/head.js';
+
+describe('head serialization', () => {
+    test('renders a title as character data', () => {
+        const html = renderHead(toHeadElements({ defaultTitle: 'Hello' }));
+
+        expect(html.trim()).toBe('<title>Hello</title>');
+    });
+
+    test('escapes text content so a title cannot open a tag', () => {
+        const html = renderHead(toHeadElements({ title: '</title><script>alert(1)</script>' }));
+
+        expect(html).not.toContain('<script>');
+        expect(html).toContain('&lt;script&gt;');
+    });
+
+    test('escapes attribute values so a quote cannot break out', () => {
+        const html = renderHead(toHeadElements({
+            meta: [{ name: 'description', content: '" onload="alert(1)' }],
+        }));
+
+        expect(html).toContain('&quot;');
+        expect(html).not.toContain('onload="alert(1)"');
+    });
+
+    // The values were escaped before this module existed, but the keys never were,
+    // and og/twitter keys can come straight from a CMS.
+    test('drops attribute names that are not valid, rather than writing them out', () => {
+        const html = renderHead(toHeadElements({
+            og: { 'title><script>alert(1)</script': 'x' },
+        }));
+
+        expect(html).not.toContain('<script>');
+    });
+
+    test('renders a boolean attribute bare, and drops a false one', () => {
+        const html = renderHead(toHeadElements({
+            script: [{ src: '/a.js', async: true, defer: false }],
+        }));
+
+        expect(html).toContain('async');
+        expect(html).not.toContain('defer');
+        expect(html).toContain('</script>');
+    });
+});
+
+describe('head merging', () => {
+    test('a page title replaces the global one instead of adding a second', () => {
+        const merged = mergeHead(
+            toHeadElements({ defaultTitle: 'Site' }),
+            toHeadElements({ title: 'Page' }),
+        );
+        const html = renderHead(merged);
+
+        expect(html.match(/<title>/g)).toHaveLength(1);
+        expect(html).toContain('<title>Page</title>');
+    });
+
+    // A page setting its own description used to ship two of them to crawlers.
+    test('a page description replaces the global one', () => {
+        const merged = mergeHead(
+            toHeadElements({ description: 'global' }),
+            toHeadElements({ description: 'page' }),
+        );
+        const html = renderHead(merged);
+
+        expect(html.match(/name="description"/g)).toHaveLength(1);
+        expect(html).toContain('page');
+    });
+
+    test('meta with different names accumulate', () => {
+        const merged = mergeHead(
+            toHeadElements({ meta: [{ name: 'viewport', content: 'width=device-width' }] }),
+            toHeadElements({ description: 'page' }),
+        );
+
+        expect(renderHead(merged)).toContain('viewport');
+        expect(renderHead(merged)).toContain('description');
+    });
+
+    test('og tags merge by property, not position', () => {
+        const merged = mergeHead(
+            toHeadElements({ og: { title: 'global', image: '/a.png' } }),
+            toHeadElements({ og: { title: 'page' } }),
+        );
+        const html = renderHead(merged);
+
+        expect(html.match(/property="og:title"/g)).toHaveLength(1);
+        expect(html).toContain('page');
+        expect(html).toContain('/a.png');
+    });
+});

--- a/tests/build/meta-injection.test.js
+++ b/tests/build/meta-injection.test.js
@@ -3,6 +3,103 @@ import { injectMetaTags } from '../../src/build/ssg.js';
 
 const TEMPLATE = '<!doctype html><html><head><script src="/main.js"></script></head><body><div id="root"></div></body></html>';
 
+// The template reaching the SSG already carries the global head config, injected
+// by the build. A route's meta has to supersede it, not queue up behind it.
+describe('injectMetaTags over an already-populated head', () => {
+    const WITH_GLOBAL_HEAD = [
+        '<!doctype html><html><head>',
+        '    <title>Site</title>',
+        '    <meta name="description" content="global">',
+        '  </head><body><div id="root"></div></body></html>',
+    ].join('\n');
+
+    test('a route title replaces the global one instead of adding a second', () => {
+        const out = injectMetaTags(WITH_GLOBAL_HEAD, { title: 'Page' });
+
+        expect(out.match(/<title>/g)).toHaveLength(1);
+        expect(out).toContain('<title>Page</title>');
+        expect(out).not.toContain('<title>Site</title>');
+    });
+
+    // Two descriptions used to be served to crawlers on every static page.
+    test('a route description replaces the global one', () => {
+        const out = injectMetaTags(WITH_GLOBAL_HEAD, { description: 'page' });
+
+        expect(out.match(/name="description"/g)).toHaveLength(1);
+        expect(out).toContain('content="page"');
+        expect(out).not.toContain('content="global"');
+    });
+
+    test('tags the route does not override are left alone', () => {
+        const out = injectMetaTags(WITH_GLOBAL_HEAD, { description: 'page' });
+
+        expect(out).toContain('<title>Site</title>');
+    });
+
+    // The build plugin anchors on the last `</head>`; this path used to anchor on
+    // the first, which lands the tags inside a script that merely holds the literal.
+    test('an inline script containing the literal </head> is left intact', () => {
+        const tricky = '<!doctype html><html><head><script>var s = "</head>";</script></head><body></body></html>';
+
+        const out = injectMetaTags(tricky, { title: 'Page' });
+
+        expect(out).toContain('var s = "</head>";');
+        expect(out.indexOf('<title>')).toBeLessThan(out.lastIndexOf('</head>'));
+    });
+
+    // Markup that only looks like a tag must not be mistaken for one: stripping the
+    // "tag" inside a comment leaves the real one in place, so the page ships two.
+    test('a meta inside an HTML comment is neither removed nor mistaken for the real one', () => {
+        const withComment = [
+            '<!doctype html><html><head>',
+            '<!-- <meta name="description" content="commented out"> -->',
+            '<meta name="description" content="global">',
+            '</head><body></body></html>',
+        ].join('');
+
+        const out = injectMetaTags(withComment, { description: 'page' });
+        const live = out.replace(/<!--[\s\S]*?-->/g, '');
+
+        expect(live.match(/name="description"/g)).toHaveLength(1);
+        expect(live).toContain('content="page"');
+        expect(live).not.toContain('content="global"');
+        expect(out).toContain('<!-- <meta name="description" content="commented out"> -->');
+    });
+
+    test('a meta that only appears inside a script body is left alone', () => {
+        const withScript = [
+            '<!doctype html><html><head>',
+            '<script>var t = "<meta name=\\"description\\">";</script>',
+            '<meta name="description" content="global">',
+            '</head><body></body></html>',
+        ].join('');
+
+        const out = injectMetaTags(withScript, { description: 'page' });
+
+        expect(out).toContain('var t = "<meta name=\\"description\\">";');
+        expect(out).toContain('content="page"');
+        expect(out).not.toContain('content="global"');
+    });
+
+    test('attribute order and quoting style do not hide the tag', () => {
+        const single = '<!doctype html><html><head><meta content=\'global\' name=\'description\'></head><body></body></html>';
+
+        const out = injectMetaTags(single, { description: 'page' });
+
+        expect(out.match(/name=["']description["']/g)).toHaveLength(1);
+        expect(out).not.toContain('global');
+    });
+
+    test('an og:title does not get taken for the document title', () => {
+        const withOg = '<!doctype html><html><head><title>Site</title><meta property="og:title" content="OG"></head><body></body></html>';
+
+        const out = injectMetaTags(withOg, { title: 'Page' });
+
+        expect(out).toContain('<title>Page</title>');
+        expect(out).toContain('property="og:title"');
+    });
+});
+
 describe('injectMetaTags', () => {
     test('injects title when none exists in template', () => {
         const out = injectMetaTags(TEMPLATE, { title: 'Hello' });

--- a/tests/integration/build.test.js
+++ b/tests/integration/build.test.js
@@ -77,6 +77,21 @@ describe('production build artifacts', () => {
         expect(html).toContain('Build fixture');
     });
 
+    // The build plugin and the SSG both write the head. They used to do so with
+    // separate serializers and opposite anchors, so a pre-rendered page ended up
+    // with the global tags AND its own, and crawlers saw two of each.
+    test('a pre-rendered page carries its own head, not a duplicated one', async () => {
+        const staticHtml = await fixture.readFile('static.html');
+
+        expect(staticHtml.match(/<title>/g)).toHaveLength(1);
+        expect(staticHtml.match(/name="description"/g)).toHaveLength(1);
+
+        // The page's own meta won over the global config.
+        expect(staticHtml).toContain('<title>Static page</title>');
+        expect(staticHtml).toContain('Pre-rendered at build time');
+        expect(staticHtml).not.toContain('content="Build fixture"');
+    });
+
     // Locks dcfc275: production shipped source maps.
     test('production emits no source maps', async () => {
         const files = await fixture.readdir();


### PR DESCRIPTION
## Why

The head had **two independent writers**:

| | Anchor | Serializer |
|---|---|---|
| `InjectHeadTagsPlugin` (rspack.config.js) | last `</head>` | `escapeText` / `renderAttributes` |
| `injectMetaTags` (ssg.js) | **first** `</head>` | `escapeHtml` / `metaTag` |

That is one bug class, found and fixed three times (`85532c5`, `ba56556`, `fdc9342`), each time in only one of the two paths. It was still live on the SSG side: the plugin's comment explains at length why anchoring on the first `</head>` corrupts an inline script that merely contains the literal, and the SSG went on doing exactly that.

## The fix

`src/build/head.js` owns everything inside `<head>`. Tags are **described**, not spelled out, merged by identity, and serialized in exactly one place. Both writers build the same descriptors. `rspack.config.js` sheds 60 lines of duplicated serialization.

## Three defects fall out of that

**Pre-rendered pages shipped two `<title>` and two meta descriptions to crawlers.** The SSG appended a route's meta to a head that already carried the global config instead of superseding it. Verified: the new integration test fails on `main` and passes here.

**Attribute names were never escaped, only values.** An `og:` or `twitter:` key coming from a CMS could carry a quote or an angle bracket and inject markup into the head of every static page. Invalid attribute names are now dropped rather than written out.

**The SSG's first-match anchor** corrupted inline scripts and dropped the head config. It now anchors on the last `</head>`, as the plugin already did.

## Removing a tag no longer trusts a regex

Stripping the tag a route overrides means finding it in markup. A naive pattern matches inside an HTML comment or a script body, removes the *fake* tag, leaves the real one, and the page ships two. Comments and script bodies are masked out (blanked to spaces of the same length, so offsets still map back) before the match.

Covered: single and double quotes, reordered attributes, a meta inside a comment, a meta-shaped string inside a script, a script holding the literal `</head>`, and `og:title` not being taken for the document title.

## Tests

80 pass. The 13 existing `injectMetaTags` tests are untouched and still green.