### PR TITLE
Extend test coverage over the runtime and CLI, fixing four bugs it surfaced

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -29,10 +29,12 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@happy-dom/global-registrator": "^20.11.1",
         "eslint": "^9.39.4",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-compiler": "^19.1.0-rc.2",
         "globals": "^16.5.0",
+        "happy-dom": "^20.11.1",
         "react": "^19.2.7",
         "react-dom": "^19.2.7",
         "react-router-dom": "^7.16.0",
@@ -119,6 +121,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@2.1.7", "", {}, "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.4.1", "", { "dependencies": { "@eslint/core": "^0.17.0", "levn": "^0.4.1" } }, "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA=="],
+
+    "@happy-dom/global-registrator": ["@happy-dom/global-registrator@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "happy-dom": "^20.11.1" } }, "sha512-1C0wwHiyMlEdsbrJqff5ORE2PwaXBOam5rMqkZVOReAezd5nt6Tl/WGg28UAo75Ziuwchs0KaF8lvnn2oAtvJA=="],
 
     "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
 
@@ -221,6 +225,10 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/node": ["@types/node@26.0.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.62.1", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.62.1", "@typescript-eslint/type-utils": "8.62.1", "@typescript-eslint/utils": "8.62.1", "@typescript-eslint/visitor-keys": "8.62.1", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.62.1", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA=="],
 
@@ -326,6 +334,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
@@ -396,7 +406,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.1", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-7DdUaTjmNwMcH2gLr1qycesKII3BK4RLy/mdAb7x10Lq7bR4aNKHt1BR1ZALSv0rPM/hF5wYF0PhGop/rJm8vw=="],
 
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -501,6 +511,8 @@
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -876,6 +888,8 @@
 
     "webpack-sources": ["webpack-sources@3.5.0", "", {}, "sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ=="],
 
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
     "which-boxed-primitive": ["which-boxed-primitive@1.1.1", "", { "dependencies": { "is-bigint": "^1.1.0", "is-boolean-object": "^1.2.1", "is-number-object": "^1.1.1", "is-string": "^1.1.1", "is-symbol": "^1.1.1" } }, "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA=="],
@@ -889,6 +903,8 @@
     "wildcard": ["wildcard@2.0.1", "", {}, "sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "ws": ["ws@8.21.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -922,7 +938,11 @@
 
     "html-minifier-terser/commander": ["commander@9.5.0", "", {}, "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="],
 
+    "html-minifier-terser/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
     "jest-worker/supports-color": ["supports-color@8.1.1", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q=="],
+
+    "parse5/entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "path-scurry/lru-cache": ["lru-cache@11.5.1", "", {}, "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A=="],
 

--- a/package.json
+++ b/package.json
@@ -67,10 +67,12 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@happy-dom/global-registrator": "^20.11.1",
     "eslint": "^9.39.4",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-compiler": "^19.1.0-rc.2",
     "globals": "^16.5.0",
+    "happy-dom": "^20.11.1",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
     "react-router-dom": "^7.16.0",

--- a/src/build/router.js
+++ b/src/build/router.js
@@ -498,11 +498,18 @@ function buildLayoutTree(pageDirectory, extensions) {
             });
 
         if (layoutFile) {
-            const layoutPath = pathPrefix ? path.join(pathPrefix, layoutFile) : layoutFile;
-            layouts.set(pathPrefix || '/', {
-                file: layoutPath,
+            const layoutFilePath = pathPrefix ? path.join(pathPrefix, layoutFile) : layoutFile;
+            // Keyed by route path, i.e. leading slash, forward slashes. `pathPrefix`
+            // is built with path.join, so it is both slash-less at the front and
+            // backslash-separated on Windows. Storing it raw made every nested
+            // layout unreachable: buildNestedRoutes looks up `'/' + segments.join('/')`,
+            // so `blog` was never found for `/blog` and the layout silently vanished
+            // from the route tree (it stayed in pages.js, bundled but unused).
+            const routePath = pathPrefix ? `/${pathPrefix.split(path.sep).join('/')}` : '/';
+            layouts.set(routePath, {
+                file: layoutFilePath,
                 component: generateLayoutName(pathPrefix),
-                path: pathPrefix || '/'
+                path: routePath
             });
         }
 
@@ -578,9 +585,12 @@ function buildNestedRoutes(pages, layoutTree) {
             nodes.push(node);
         });
 
-        // Add nested layouts
+        // Add nested layouts. Compared on segment boundaries rather than with a
+        // bare startsWith: `/blogger` starts with `/blog` as a string but is not
+        // nested under it, and would otherwise be pulled inside that layout.
+        const prefix = currentPath === '/' ? '/' : `${currentPath}/`;
         Array.from(layoutTree.keys())
-            .filter(layoutPath => layoutPath.startsWith(currentPath) && layoutPath !== currentPath)
+            .filter(layoutPath => layoutPath.startsWith(prefix) && layoutPath !== currentPath)
             .forEach(layoutPath => {
                 const layout = layoutTree.get(layoutPath);
                 nodes.push({

--- a/src/command/router.js
+++ b/src/command/router.js
@@ -4,34 +4,98 @@ import Table from "cli-table3";
 import fs from "fs";
 
 
-// Function to check if URL matches a route pattern with requirements
-const matchRoute = (url, routePath, requirements = {}) => {
-  // Convert React Router path to regex
-  let pattern = routePath.replace(/\//g, '\\/');  // Escape forward slashes
-  
-  // Get parameter names first
-  const paramNames = [...routePath.matchAll(/:([^/]+)/g)].map(m => m[1]);
-  
-  // Replace each parameter with its requirement pattern or default
-  paramNames.forEach(paramName => {
-    const requirement = requirements[paramName] || '[^/]+';
-    pattern = pattern.replace(`:${paramName}`, `(${requirement})`);
+/**
+ * Tests a URL against a route path, honouring the route's `requirements`.
+ *
+ * Exported for tests: the URL-to-route answer this gives is the whole point of
+ * `aplos router:match`, and it is pure logic worth pinning directly.
+ *
+ * The path is built segment by segment rather than by patching a half-escaped
+ * string. The previous version escaped `/` only and left every other regex
+ * metacharacter live, so the `*` that `buildRouter` emits for a catch-all
+ * (`[...slug]` becomes `*`) was read as a quantifier: `/blog/*` compiled to
+ * `^\/blog\/*$`, which does not match `/blog/hello`. Every catch-all route in a
+ * project reported "does not match any route" while `router:debug` listed it.
+ * A literal `.` or `+` in a static path was mis-handled the same way.
+ */
+export const matchRoute = (url, routePath, requirements = {}) => {
+  const paramNames = [];
+
+  // `*` (catch-all) and `:param` are the only two dynamic constructs; everything
+  // else is literal text and gets escaped.
+  const pattern = routePath.replace(/\*|:([^/]+)|[^*:]+|:/g, (token, paramName) => {
+    if (token === '*') {
+      return '(.*)';
+    }
+    if (paramName) {
+      paramNames.push(paramName);
+      const requirement = requirements[paramName] || '[^/]+';
+      // Each param must contribute exactly ONE capture group, in order, or the
+      // index-based binding below hands a param its neighbour's value. A
+      // requirement is free to contain its own groups (`(\\d+)`, `(a|b)`), so
+      // they are demoted to non-capturing before wrapping.
+      return `(${neutralizeGroups(requirement)})`;
+    }
+    return escapeForRegExp(token);
   });
-    
-  const regex = new RegExp(`^${pattern}$`);
-  const match = url.match(regex);
-  
-  if (match) {
-    // Extract parameters
-    const params = {};
-    paramNames.forEach((name, index) => {
-      params[name] = match[index + 1];
-    });
-    return { match: true, params };
+
+  let regex;
+  try {
+    regex = new RegExp(`^${pattern}$`);
+  } catch {
+    // A malformed requirement must not crash the CLI.
+    return { match: false };
   }
-  
-  return { match: false };
+
+  const match = url.match(regex);
+  if (!match) {
+    return { match: false };
+  }
+
+  const params = {};
+  paramNames.forEach((name, index) => {
+    params[name] = match[index + 1];
+  });
+  return { match: true, params };
 };
+
+function escapeForRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Turns capturing groups in a user-supplied requirement into non-capturing ones,
+ * so each route param still owns exactly one group.
+ *
+ * A `(` that is escaped (`\(`) or already special (`(?:`, `(?=`, `(?<name>`) is
+ * left alone. The scan tracks escapes and character classes, where `(` is a
+ * literal and must not be rewritten.
+ */
+function neutralizeGroups(requirement) {
+  let out = '';
+  let inClass = false;
+
+  for (let i = 0; i < requirement.length; i++) {
+    const char = requirement[i];
+
+    if (char === '\\') {
+      // Copy the escape and whatever it escapes, verbatim.
+      out += char + (requirement[i + 1] ?? '');
+      i++;
+      continue;
+    }
+    if (char === '[') inClass = true;
+    else if (char === ']') inClass = false;
+
+    if (char === '(' && !inClass && requirement[i + 1] !== '?') {
+      out += '(?:';
+      continue;
+    }
+    out += char;
+  }
+
+  return out;
+}
 
 export default async (options) => {
   let projectDirectory = process.cwd();

--- a/src/command/router.js
+++ b/src/command/router.js
@@ -159,6 +159,10 @@ export default async (options) => {
         }
       });
       console.log(availableTable.toString());
+      // A failed match exits non-zero so the command can be scripted: `aplos
+      // router:match "$url" || …` was previously indistinguishable from a hit,
+      // since both returned 0.
+      process.exitCode = 1;
     }
     return;
   }
@@ -187,15 +191,22 @@ export default async (options) => {
       console.log(table.toString());
     } else {
       console.log("Component not found");
+      process.exitCode = 1;
     }
   } else {
     const table = new Table({
       head: ["Component", "File", "Scheme", "Host", "Path"],
     });
 
-    routes.map((route) => {
-      table.push([route.component, route.file ? `src/pages${route.file}` : "-", "Any", "Any", route.path]);
-    });
+    // `.aplos/cache/router.js` holds the page routes AND the raw route-config
+    // entries from aplos.config.js, which carry `source`/`paths` but no
+    // component or path. Listing those rendered a fully blank table row. The
+    // match branch above already guards this the same way.
+    routes
+      .filter((route) => route.path)
+      .forEach((route) => {
+        table.push([route.component, route.file ? `src/pages${route.file}` : "-", "Any", "Any", route.path]);
+      });
     console.log(table.toString());
   }
 };

--- a/src/runtime/MiddlewareGate.jsx
+++ b/src/runtime/MiddlewareGate.jsx
@@ -92,7 +92,23 @@ function ActiveMiddlewareGate({ children }) {
                     return;
                 }
                 redirectChainRef.current += 1;
-                navigate(result.to, { replace: result.replace });
+                // Deferred by a microtask rather than called inline. React Router
+                // v7 drops a navigate() issued synchronously from a mount-time
+                // layout effect: the history entry does change (BrowserRouter
+                // updates window.location) but the router never re-renders, so
+                // the app is stuck on the `null` frame below, i.e. a permanently
+                // blank page. It is specific to the *first* mount; later
+                // navigations work inline. Yielding one microtask lets React
+                // finish its initial commit, after which navigate() is honoured.
+                //
+                // This does NOT weaken the anti-flash guarantee: `decidedFor`
+                // stays unset for this location, so the guarded tree is still
+                // never committed. The gate renders `null` until the redirect
+                // target settles.
+                queueMicrotask(() => {
+                    if (cancelled) return;
+                    navigate(result.to, { replace: result.replace });
+                });
                 // Leave `decidedFor` unset for this location: the navigate()
                 // will change the location and re-run this effect for the new
                 // target, which is where the decision that matters is made.

--- a/tests/build/inject-meta.test.js
+++ b/tests/build/inject-meta.test.js
@@ -1,0 +1,155 @@
+import { describe, test, expect } from 'bun:test';
+import { injectMetaTags } from '../../src/build/ssg.js';
+
+// `injectMetaTags` layers a route's head over a document that already carries the
+// global head config. It is pure string work, so it is tested directly rather than
+// through a full build: the integration suite proves the wiring, these prove the
+// edge cases that made this function grow its comments.
+const page = (head) => `<!doctype html><html><head>\n${head}\n</head><body><div id="root"></div></body></html>`;
+
+describe('injectMetaTags', () => {
+    test('returns the document untouched when the route declares no head', () => {
+        const html = page('  <title>Global</title>');
+
+        expect(injectMetaTags(html, {})).toBe(html);
+        expect(injectMetaTags(html, null)).toBe(html);
+    });
+
+    test('returns the document untouched when there is no head to anchor on', () => {
+        const html = '<html><body>no head here</body></html>';
+
+        expect(injectMetaTags(html, { title: 'Route' })).toBe(html);
+    });
+
+    test('a route title replaces the global one instead of queueing behind it', () => {
+        const result = injectMetaTags(page('  <title>Global</title>'), { title: 'Route' });
+
+        expect(result.match(/<title>/g)).toHaveLength(1);
+        expect(result).toContain('<title>Route</title>');
+        expect(result).not.toContain('<title>Global</title>');
+    });
+
+    test('a route description replaces the global one', () => {
+        const html = page('  <meta name="description" content="Global">');
+
+        const result = injectMetaTags(html, { meta: [{ name: 'description', content: 'Route' }] });
+
+        expect(result.match(/name="description"/g)).toHaveLength(1);
+        expect(result).toContain('content="Route"');
+        expect(result).not.toContain('content="Global"');
+    });
+
+    test('matches a global tag regardless of how its attribute is quoted', () => {
+        const html = page("  <meta name='description' content='Global'>");
+
+        const result = injectMetaTags(html, { meta: [{ name: 'description', content: 'Route' }] });
+
+        expect(result.match(/name=["']description["']/g)).toHaveLength(1);
+        expect(result).not.toContain('Global');
+    });
+
+    test('an og: property is replaced by property, not by name', () => {
+        const html = page('  <meta property="og:title" content="Global">');
+
+        const result = injectMetaTags(html, {
+            meta: [{ property: 'og:title', content: 'Route' }],
+        });
+
+        expect(result.match(/property="og:title"/g)).toHaveLength(1);
+        expect(result).toContain('content="Route"');
+    });
+
+    test('a canonical link is replaced, other links accumulate', () => {
+        const html = page(
+            '  <link rel="canonical" href="https://example.com/old">\n' +
+            '  <link rel="stylesheet" href="/app.css">',
+        );
+
+        const result = injectMetaTags(html, {
+            link: [{ rel: 'canonical', href: 'https://example.com/new' }],
+        });
+
+        expect(result.match(/rel="canonical"/g)).toHaveLength(1);
+        expect(result).toContain('https://example.com/new');
+        expect(result).not.toContain('https://example.com/old');
+        // Stylesheets are not self-identifying: they must survive untouched.
+        expect(result).toContain('/app.css');
+    });
+
+    test('a meta with neither name nor property is left alone', () => {
+        const html = page('  <meta charset="utf-8">');
+
+        const result = injectMetaTags(html, { meta: [{ charset: 'utf-8' }] });
+
+        // Nothing was removed; the route tag is appended alongside.
+        expect(result.match(/charset/g).length).toBeGreaterThanOrEqual(2);
+    });
+
+    // The regression the `replaceOutsideInertRegions` helper exists for: a tag
+    // pattern happily matches inside a comment or a script body, where the text
+    // merely looks like markup. Stripping it there leaves the real tag in place
+    // (so the page ships two titles) and corrupts the script.
+    describe('inert regions are never treated as markup', () => {
+        test('a title inside an inline script is not mistaken for the real one', () => {
+            const html = page(
+                '  <script>const tpl = "<title>Not the real one</title>";</script>\n' +
+                '  <title>Global</title>',
+            );
+
+            const result = injectMetaTags(html, { title: 'Route' });
+
+            // The script body survives byte for byte.
+            expect(result).toContain('const tpl = "<title>Not the real one</title>";');
+            // And the real title was the one replaced.
+            expect(result).toContain('<title>Route</title>');
+            expect(result).not.toContain('<title>Global</title>');
+        });
+
+        test('a meta inside an HTML comment is not mistaken for the real one', () => {
+            const html = page(
+                '  <!-- <meta name="description" content="Commented out"> -->\n' +
+                '  <meta name="description" content="Global">',
+            );
+
+            const result = injectMetaTags(html, {
+                meta: [{ name: 'description', content: 'Route' }],
+            });
+
+            expect(result).toContain('<!-- <meta name="description" content="Commented out"> -->');
+            expect(result).toContain('content="Route"');
+            expect(result).not.toContain('content="Global"');
+        });
+    });
+
+    // Anchoring on the FIRST `</head>` lands the tags inside an inline script that
+    // merely contains the literal, dropping them from the head entirely.
+    test('tags are anchored on the last </head>, not a literal inside a script', () => {
+        const html = page('  <script>const s = "</head>";</script>');
+
+        const result = injectMetaTags(html, { title: 'Route' });
+
+        expect(result).toContain('const s = "</head>";');
+        // The title landed in the real head: before the body, after the script.
+        const titleIndex = result.indexOf('<title>Route</title>');
+        const bodyIndex = result.indexOf('<body>');
+        expect(titleIndex).toBeGreaterThan(-1);
+        expect(titleIndex).toBeLessThan(bodyIndex);
+    });
+
+    test('a name containing regex metacharacters is matched literally', () => {
+        const html = page('  <meta name="a.b*c" content="Global">');
+
+        const result = injectMetaTags(html, { meta: [{ name: 'a.b*c', content: 'Route' }] });
+
+        expect(result.match(/name="a\.b\*c"/g)).toHaveLength(1);
+        expect(result).toContain('content="Route"');
+    });
+
+    test('removing a tag does not leave a blank line where it stood', () => {
+        const html = page('  <title>Global</title>');
+
+        const result = injectMetaTags(html, { title: 'Route' });
+
+        expect(result).not.toMatch(/\n[ \t]*\n[ \t]*\n/);
+    });
+});

--- a/tests/build/nested-layouts.test.js
+++ b/tests/build/nested-layouts.test.js
@@ -1,0 +1,141 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { buildRouter } from '../../src/build/router.js';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const dirs = [];
+
+async function scaffold(files) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aplos-layouts-'));
+    dirs.push(dir);
+
+    for (const [file, contents] of Object.entries(files)) {
+        const target = path.join(dir, 'src', 'pages', file);
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, contents, 'utf-8');
+    }
+
+    return dir;
+}
+
+async function buildTree(dir) {
+    const original = process.cwd;
+    process.cwd = () => dir;
+    try {
+        await buildRouter({ routes: [] });
+    } finally {
+        process.cwd = original;
+    }
+
+    return fs.readFile(path.join(dir, '.aplos', 'cache', 'routes.js'), 'utf-8');
+}
+
+/** Finds the node wrapping `component`, and returns the paths nested under it. */
+function childPathsOf(routesSource, component) {
+    // routes.js is generated JS, not JSON, so the tree is read by locating the
+    // component and scanning its `children` block.
+    const marker = `element: ${component}`;
+    const start = routesSource.indexOf(marker);
+    if (start === -1) return null;
+
+    const childrenIndex = routesSource.indexOf('children:', start);
+    if (childrenIndex === -1) return null;
+
+    // Walk to the matching closing bracket of the children array.
+    const open = routesSource.indexOf('[', childrenIndex);
+    let depth = 0;
+    let end = open;
+    for (; end < routesSource.length; end++) {
+        if (routesSource[end] === '[') depth++;
+        else if (routesSource[end] === ']') {
+            depth--;
+            if (depth === 0) break;
+        }
+    }
+
+    const block = routesSource.slice(open, end);
+    return [...block.matchAll(/path:\s*"([^"]*)"/g)].map((m) => m[1]);
+}
+
+const PAGE = 'export default () => null';
+const LAYOUT = 'export default ({ children }) => children';
+
+afterEach(async () => {
+    while (dirs.length) {
+        await fs.rm(dirs.pop(), { recursive: true, force: true });
+    }
+});
+
+// Nested layouts were emitted into pages.js but never reached the route tree:
+// scanLayouts keyed the map with a path.join prefix (`blog`) while the tree
+// builder looked up a route path (`/blog`). The lookup never hit, so a project
+// following the documented `_layout.jsx` convention got a flat tree, the layout
+// silently absent and bundled but unused.
+describe('nested layouts reach the route tree', () => {
+    test('a page under a directory with _layout is nested inside it', async () => {
+        const dir = await scaffold({
+            'index.jsx': PAGE,
+            'blog/_layout.jsx': LAYOUT,
+            'blog/index.jsx': PAGE,
+        });
+
+        const routes = await buildTree(dir);
+
+        expect(routes).toContain('BlogLayout');
+        expect(childPathsOf(routes, 'BlogLayout')).toEqual(['/blog']);
+    });
+
+    test('every page under the layout directory is nested, siblings are not', async () => {
+        const dir = await scaffold({
+            'index.jsx': PAGE,
+            'about.jsx': PAGE,
+            'blog/_layout.jsx': LAYOUT,
+            'blog/index.jsx': PAGE,
+            'blog/post.jsx': PAGE,
+        });
+
+        const routes = await buildTree(dir);
+
+        const nested = childPathsOf(routes, 'BlogLayout');
+        expect(nested).toContain('/blog');
+        expect(nested).toContain('/blog/post');
+        expect(nested).not.toContain('/');
+        expect(nested).not.toContain('/about');
+    });
+
+    // `/blogger` starts with `/blog` as a string but is not nested under it.
+    // Both directories need their own layout for this to bite: the nesting is
+    // decided by comparing layout keys, so a sibling without one is never a
+    // candidate in the first place.
+    test('a sibling layout sharing a name prefix is not nested inside it', async () => {
+        const dir = await scaffold({
+            'index.jsx': PAGE,
+            'blog/_layout.jsx': LAYOUT,
+            'blog/index.jsx': PAGE,
+            'blogger/_layout.jsx': LAYOUT,
+            'blogger/index.jsx': PAGE,
+        });
+
+        const routes = await buildTree(dir);
+
+        // BloggerLayout must be a sibling of BlogLayout, not one of its children.
+        expect(childPathsOf(routes, 'BlogLayout')).toEqual(['/blog']);
+        expect(childPathsOf(routes, 'BloggerLayout')).toEqual(['/blogger']);
+        expect(routes.indexOf('BloggerLayout')).toBeGreaterThan(-1);
+    });
+
+    test('a project with no nested layout still builds a flat tree', async () => {
+        const dir = await scaffold({
+            'index.jsx': PAGE,
+            'about.jsx': PAGE,
+        });
+
+        const routes = await buildTree(dir);
+
+        expect(routes).toContain('AppLayout');
+        const paths = childPathsOf(routes, 'AppLayout');
+        expect(paths).toContain('/');
+        expect(paths).toContain('/about');
+    });
+});

--- a/tests/command/router-cli.test.js
+++ b/tests/command/router-cli.test.js
@@ -1,0 +1,121 @@
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frameworkDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+const ANSI_PATTERN = new RegExp(String.fromCharCode(27) + String.raw`\[[0-9;]*m`, 'g');
+
+// cli-table3 emits colour codes even when piped; strip them so assertions match
+// on text rather than on escape sequences. Built from a char code because the
+// literal escape character is not allowed in a regex by lint (no-control-regex).
+function stripAnsi(value) {
+    return value.replace(ANSI_PATTERN, '');
+}
+
+// The CLI is driven as a subprocess: the exit code is part of the contract these
+// tests pin, and it is only observable from outside the process.
+function runCli(cwd, args) {
+    return new Promise((resolve) => {
+        const child = spawn(process.execPath, [path.join(frameworkDir, 'bin', 'aplos'), ...args], {
+            cwd,
+            env: { ...process.env, FORCE_COLOR: '0' },
+        });
+
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d) => { stdout += d; });
+        child.stderr.on('data', (d) => { stderr += d; });
+        child.on('close', (code) => resolve({
+            code,
+            stdout: stripAnsi(stdout),
+            stderr,
+        }));
+    });
+}
+
+let project;
+
+beforeAll(async () => {
+    project = await fs.mkdtemp(path.join(os.tmpdir(), 'aplos-cli-'));
+
+    const pages = path.join(project, 'src', 'pages', 'blog');
+    await fs.mkdir(pages, { recursive: true });
+    await fs.writeFile(path.join(project, 'src', 'pages', 'index.jsx'), 'export default () => null');
+    await fs.writeFile(path.join(pages, '[...slug].jsx'), 'export default () => null');
+
+    // A route-config entry with `source`/`paths` but no component: this is what
+    // used to render a blank row in the debug table.
+    await fs.writeFile(
+        path.join(project, 'aplos.config.js'),
+        "export default { routes: [{ source: '/blog/[...slug]', paths: ['/blog/a'] }] };\n",
+    );
+});
+
+afterAll(() => fs.rm(project, { recursive: true, force: true }));
+
+describe('aplos router:debug', () => {
+    test('lists the project routes', async () => {
+        const { code, stdout } = await runCli(project, ['router:debug']);
+
+        expect(code).toBe(0);
+        expect(stdout).toContain('Index');
+        expect(stdout).toContain('/blog/*');
+    });
+
+    // The cache holds page routes AND raw aplos.config.js entries, which have no
+    // component or path. Those rendered as a junk row: empty Component and Path,
+    // with the table's own placeholders ("-", "Any") filling the rest. Asserting
+    // "some cell is non-empty" would NOT catch it, since those placeholders are
+    // non-empty; the identifying trait is an empty Component *and* Path.
+    test('does not render a junk row for config-only route entries', async () => {
+        const { stdout } = await runCli(project, ['router:debug']);
+
+        const rows = stdout
+            .split('\n')
+            .filter((line) => line.startsWith('│'))
+            .map((line) => line.split('│').slice(1, -1).map((cell) => cell.trim()))
+            // Drop the header row.
+            .filter((cells) => cells[0] !== 'Component');
+
+        expect(rows.length).toBe(2);
+        for (const [component, , , , routePath] of rows) {
+            expect(component).not.toBe('');
+            expect(routePath).not.toBe('');
+        }
+    });
+
+    test('exits non-zero when the component does not exist', async () => {
+        const { code, stdout } = await runCli(project, ['router:debug', 'NoSuchComponent']);
+
+        expect(stdout).toContain('Component not found');
+        expect(code).toBe(1);
+    });
+
+    test('exits zero when the component exists', async () => {
+        const { code } = await runCli(project, ['router:debug', 'Index']);
+
+        expect(code).toBe(0);
+    });
+});
+
+describe('aplos router:match', () => {
+    // Locks the catch-all fix: `[...slug]` becomes `*`, which used to compile as
+    // a quantifier and made every catch-all report "does not match".
+    test('matches a catch-all route and exits zero', async () => {
+        const { code, stdout } = await runCli(project, ['router:match', '/blog/hello']);
+
+        expect(stdout).toContain('matches route');
+        expect(code).toBe(0);
+    });
+
+    test('exits non-zero when no route matches', async () => {
+        const { code, stdout } = await runCli(project, ['router:match', '/nope']);
+
+        expect(stdout).toContain('does not match any route');
+        expect(code).toBe(1);
+    });
+});

--- a/tests/command/router-match.test.js
+++ b/tests/command/router-match.test.js
@@ -1,0 +1,112 @@
+import { describe, test, expect } from 'bun:test';
+import { matchRoute } from '../../src/command/router.js';
+
+// `aplos router:match <url>` answers "does this URL hit one of my routes, and
+// with what params". `matchRoute` is that answer, so it is tested directly.
+describe('matchRoute: static paths', () => {
+    test('matches an exact path', () => {
+        expect(matchRoute('/', '/').match).toBe(true);
+        expect(matchRoute('/about', '/about').match).toBe(true);
+    });
+
+    test('does not match a different path', () => {
+        expect(matchRoute('/about', '/contact').match).toBe(false);
+        expect(matchRoute('/about/team', '/about').match).toBe(false);
+    });
+
+    // A literal `.` in a path used to be compiled as "any character", so
+    // `/docs/axb` wrongly matched the page at `/docs/a.b`.
+    test('a dot in a static path is literal, not a wildcard', () => {
+        expect(matchRoute('/docs/a.b', '/docs/a.b').match).toBe(true);
+        expect(matchRoute('/docs/axb', '/docs/a.b').match).toBe(false);
+    });
+
+    test('a plus in a static path does not blow up the pattern', () => {
+        expect(matchRoute('/c++', '/c++').match).toBe(true);
+        expect(matchRoute('/cc', '/c++').match).toBe(false);
+    });
+});
+
+// The regression this file exists for. `buildRouter` turns `[...slug]` into `*`,
+// so catch-alls are ordinary framework output, yet `*` was compiled as a
+// quantifier on the preceding slash. Every catch-all route reported "does not
+// match any route" while `router:debug` listed it one line above.
+describe('matchRoute: catch-all routes', () => {
+    test('a catch-all matches a single segment', () => {
+        expect(matchRoute('/blog/hello', '/blog/*').match).toBe(true);
+    });
+
+    test('a catch-all matches several segments', () => {
+        expect(matchRoute('/blog/2024/01/post', '/blog/*').match).toBe(true);
+    });
+
+    test('a root-level catch-all matches', () => {
+        expect(matchRoute('/anything', '/*').match).toBe(true);
+        expect(matchRoute('/a/b/c', '/*').match).toBe(true);
+    });
+
+    test('a catch-all does not match its bare prefix', () => {
+        // `/blog/*` describes something *under* /blog.
+        expect(matchRoute('/blog', '/blog/*').match).toBe(false);
+    });
+});
+
+describe('matchRoute: params and requirements', () => {
+    test('binds a param with no requirement', () => {
+        const result = matchRoute('/blog/42', '/blog/:id');
+
+        expect(result.match).toBe(true);
+        expect(result.params).toEqual({ id: '42' });
+    });
+
+    test('a param does not span a slash by default', () => {
+        expect(matchRoute('/blog/a/b', '/blog/:id').match).toBe(false);
+    });
+
+    test('honours a requirement', () => {
+        expect(matchRoute('/blog/42', '/blog/:id', { id: '\\d+' }).match).toBe(true);
+        expect(matchRoute('/blog/abc', '/blog/:id', { id: '\\d+' }).match).toBe(false);
+    });
+
+    test('binds several params in order', () => {
+        const result = matchRoute('/u/7/p/9', '/u/:uid/p/:pid');
+
+        expect(result.params).toEqual({ uid: '7', pid: '9' });
+    });
+
+    // A requirement bringing its own capture group used to shift every later
+    // param onto its neighbour's value: `pid` came back as `1` instead of `2`.
+    test('a requirement carrying its own group does not shift the others', () => {
+        const result = matchRoute('/u/1/p/2', '/u/:uid/p/:pid', {
+            uid: '(\\d+)',
+            pid: '\\d+',
+        });
+
+        expect(result.params).toEqual({ uid: '1', pid: '2' });
+    });
+
+    test('an alternation requirement binds the whole match', () => {
+        const result = matchRoute('/u/ab/p/2', '/u/:uid/p/:pid', {
+            uid: '(a|b)+',
+            pid: '\\d+',
+        });
+
+        expect(result.params).toEqual({ uid: 'ab', pid: '2' });
+    });
+
+    test('an escaped parenthesis in a requirement stays literal', () => {
+        const result = matchRoute('/x/a(b', '/x/:v', { v: 'a\\(b' });
+
+        expect(result.params).toEqual({ v: 'a(b' });
+    });
+
+    test('a parenthesis inside a character class is not a group', () => {
+        expect(matchRoute('/x/a', '/x/:v', { v: '[(]?a' }).params).toEqual({ v: 'a' });
+    });
+
+    // A typo in aplos.config.js must not take the CLI down with it.
+    test('a malformed requirement reports no match instead of throwing', () => {
+        expect(() => matchRoute('/x/y', '/x/:v', { v: '([unclosed' })).not.toThrow();
+        expect(matchRoute('/x/y', '/x/:v', { v: '([unclosed' }).match).toBe(false);
+    });
+});

--- a/tests/runtime/middleware-gate.test.jsx
+++ b/tests/runtime/middleware-gate.test.jsx
@@ -1,0 +1,240 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+// Registered here rather than through a global `bunfig.toml` preload: the build
+// tests run in a plain Node-like environment and must keep doing so. Registering
+// per-file keeps the DOM confined to the runtime suite. The guard matters because
+// a second register() throws ("Happy DOM has already been globally registered").
+if (typeof window === 'undefined') {
+    GlobalRegistrator.register();
+}
+
+// `@aplos_middleware` and `aplos/internal/default-middleware` are rspack aliases:
+// neither resolves on disk under `bun test`, so both must be mocked before the
+// component is imported.
+//
+// The user middleware is mocked as a stable function that forwards to a mutable
+// holder. Swapping `holder.impl` per test changes behaviour WITHOUT changing the
+// module's export identity, which matters because MiddlewareGate computes
+// `HAS_MIDDLEWARE = userMiddleware !== defaultMiddleware` once at import time.
+// Re-mocking with a fresh function per test would be a no-op at best, and would
+// silently flip that constant at worst.
+const holder = { impl: () => undefined };
+
+mock.module('@aplos_middleware', () => ({
+    default: (context) => holder.impl(context),
+}));
+
+mock.module('aplos/internal/default-middleware', () => ({
+    default: function defaultMiddleware() {
+        return undefined;
+    },
+}));
+
+const React = await import('react');
+const { createRoot } = await import('react-dom/client');
+
+const { MemoryRouter, Routes, Route } = await import('react-router-dom');
+const { redirect } = await import('../../src/runtime/redirect.js');
+// Imported AFTER the mocks so its module-level `HAS_MIDDLEWARE` sees them.
+const MiddlewareGate = (await import('../../src/runtime/MiddlewareGate.jsx')).default;
+
+// A real timer flush rather than `act()`: the gate settles through a layout
+// effect, a microtask and (for async middleware) a promise, and act() would mask
+// ordering bugs between them. 60ms is far longer than any of those need.
+function flush(ms = 60) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+let container;
+let root;
+let consoleErrors;
+let originalConsoleError;
+
+beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    consoleErrors = [];
+    originalConsoleError = console.error;
+    console.error = (...args) => {
+        consoleErrors.push(args.map(String).join(' '));
+    };
+});
+
+afterEach(() => {
+    console.error = originalConsoleError;
+    root.unmount();
+    container.remove();
+    holder.impl = () => undefined;
+});
+
+// Renders the gate over two routes: `/dashboard` is guarded, `/login` is the
+// redirect target. Returns the DOM after everything has settled.
+async function renderGate({ initial = '/dashboard', onRender } = {}) {
+    function Guarded() {
+        if (onRender) onRender();
+        return <p>SECRET</p>;
+    }
+
+    root.render(
+        <MemoryRouter initialEntries={[initial]}>
+            <MiddlewareGate>
+                <Routes>
+                    <Route path="/dashboard" element={<Guarded />} />
+                    <Route path="/login" element={<p>LOGIN</p>} />
+                    <Route path="/onboarding" element={<p>ONBOARDING</p>} />
+                </Routes>
+            </MiddlewareGate>
+        </MemoryRouter>,
+    );
+
+    await flush();
+    return container.innerHTML;
+}
+
+describe('MiddlewareGate: redirect on cold load', () => {
+    // The regression this suite exists for. A sync middleware redirecting on the
+    // very first mount used to leave the app on a permanently blank page:
+    // react-router v7 drops a navigate() issued synchronously from a mount-time
+    // layout effect. This is the exact case the docs recommend for auth guards
+    // (`redirect('/login')`), and the user hits it by pasting a protected URL.
+    test('a sync middleware redirecting on first mount lands on the target', async () => {
+        holder.impl = ({ pathname }) => (pathname === '/dashboard' ? redirect('/login') : undefined);
+
+        const html = await renderGate();
+
+        expect(html).toContain('LOGIN');
+        expect(html).not.toBe('');
+    });
+
+    test('the guarded route is never rendered when the middleware redirects', async () => {
+        holder.impl = ({ pathname }) => (pathname === '/dashboard' ? redirect('/login') : undefined);
+
+        let guardedRenders = 0;
+        await renderGate({ onRender: () => { guardedRenders += 1; } });
+
+        // The whole point of deciding in a layout effect: the protected tree must
+        // never be committed, not even for one frame.
+        expect(guardedRenders).toBe(0);
+    });
+
+    // Unmounting between the layout effect and the queued microtask must not
+    // throw or warn: the redirect is fired one microtask later, by which point a
+    // route change or a hot update may have torn the tree down.
+    //
+    // Honest scope note: this asserts the teardown is clean, NOT that the
+    // `cancelled` guard inside the microtask is present. Removing that guard
+    // keeps this test green, because navigating an unmounted MemoryRouter is
+    // silently inert. Proving the guard would need the router instrumented, and
+    // mocking `react-router-dom` wholesale breaks the other tests in this file.
+    // The guard is still correct (it avoids the work and matches the effect's
+    // own cleanup contract); it is simply not pinned by a test.
+    test('unmounting with a redirect in flight is clean', async () => {
+        holder.impl = ({ pathname }) => (pathname === '/dashboard' ? redirect('/login') : undefined);
+
+        root.render(
+            <MemoryRouter initialEntries={['/dashboard']}>
+                <MiddlewareGate>
+                    <Routes>
+                        <Route path="/dashboard" element={<p>SECRET</p>} />
+                        <Route path="/login" element={<p>LOGIN</p>} />
+                    </Routes>
+                </MiddlewareGate>
+            </MemoryRouter>,
+        );
+
+        // Unmount synchronously: the layout effect has run and queued the
+        // microtask, but the microtask has not fired yet.
+        root.unmount();
+        await flush();
+
+        expect(container.innerHTML).toBe('');
+        expect(consoleErrors.join('\n')).not.toContain('unmounted');
+
+        // afterEach unmounts again; make that a no-op rather than a double
+        // unmount on an already-torn-down root.
+        root = createRoot(document.createElement('div'));
+    });
+
+    test('an async middleware redirecting on first mount lands on the target', async () => {
+        holder.impl = async ({ pathname }) => (pathname === '/dashboard' ? redirect('/login') : undefined);
+
+        const html = await renderGate();
+
+        expect(html).toContain('LOGIN');
+    });
+
+    test('a redirect chain settles on the final destination', async () => {
+        holder.impl = ({ pathname }) => {
+            if (pathname === '/dashboard') return redirect('/onboarding');
+            if (pathname === '/onboarding') return redirect('/login');
+            return undefined;
+        };
+
+        const html = await renderGate();
+
+        expect(html).toContain('LOGIN');
+    });
+});
+
+describe('MiddlewareGate: letting navigation through', () => {
+    test('renders the route when the middleware returns nothing', async () => {
+        holder.impl = () => undefined;
+
+        const html = await renderGate();
+
+        expect(html).toContain('SECRET');
+    });
+
+    test('passes the location to the middleware', async () => {
+        let received = null;
+        holder.impl = (context) => { received = context; };
+
+        await renderGate({ initial: '/dashboard?tab=billing#top' });
+
+        expect(received).not.toBeNull();
+        expect(received.pathname).toBe('/dashboard');
+        expect(received.search).toBe('?tab=billing');
+        expect(received.searchParams.get('tab')).toBe('billing');
+        expect(received.hash).toBe('#top');
+    });
+});
+
+describe('MiddlewareGate: failure modes must not wedge the app', () => {
+    test('a throwing middleware fails open and renders the route', async () => {
+        holder.impl = () => {
+            throw new Error('boom');
+        };
+
+        const html = await renderGate();
+
+        expect(html).toContain('SECRET');
+        expect(consoleErrors.join('\n')).toContain('route middleware threw');
+    });
+
+    test('a rejected async middleware fails open and renders the route', async () => {
+        holder.impl = () => Promise.reject(new Error('nope'));
+
+        const html = await renderGate();
+
+        expect(html).toContain('SECRET');
+        expect(consoleErrors.join('\n')).toContain('async route middleware rejected');
+    });
+
+    // A middleware that redirects to a path it also intercepts would loop
+    // forever, freezing the app on a blank page. The gate bounds the chain and
+    // fails open instead.
+    test('an unsettling redirect cycle is aborted and the route renders', async () => {
+        // Every path redirects somewhere else: the chain never settles.
+        holder.impl = ({ pathname }) =>
+            (pathname === '/login' ? redirect('/dashboard') : redirect('/login'));
+
+        const html = await renderGate();
+
+        // Failing open means *something* renders rather than a hung blank page.
+        expect(html).not.toBe('');
+        expect(consoleErrors.join('\n')).toContain('without settling');
+    });
+});


### PR DESCRIPTION
Extends test coverage over the runtime and the CLI. Writing the tests surfaced four real bugs, each fixed here alongside the test that pins it.

## Bugs found and fixed

**1. A middleware redirect was dropped on cold load, leaving a blank page.**

React Router v7 silently drops a `navigate()` issued synchronously from a mount-time layout effect: the history entry changes but the router never re-renders, so the gate stayed on its `null` frame forever. A user pasting a protected URL with a sync auth guard (`redirect('/login')`, the pattern the docs recommend) got a permanently blank page. Async middleware was unaffected, which is why it went unnoticed. Deferring the navigate by one microtask fixes it without weakening the anti-flash guarantee: the guarded tree is still never committed.

**2. Nested `_layout.jsx` files never reached the route tree.**

`scanLayouts` keyed the layout map with a `path.join` prefix (`blog`) while the tree builder looked it up as a route path (`/blog`). The lookup never hit, so a project following the documented convention got a flat tree: the layout was exported into `pages.js`, bundled, and never rendered. No error, no warning. Only the root layout ever worked. Keys are now normalised to route paths, and nesting is compared on segment boundaries so `/blogger` is not pulled inside `/blog`.

**3. `router:match` reported "no match" for every catch-all route.**

`buildRouter` turns `[...slug]` into `*`, so catch-alls are ordinary output, but the path was escaped for `/` only. `*` compiled as a quantifier: `/blog/*` became `^\/blog\/*$`, which does not match `/blog/hello`. The CLI contradicted itself, `router:debug` listing the route one line above `router:match` denying it. Literal `.` and `+` in static paths were mis-handled the same way, and a requirement carrying its own capture group shifted every later param onto its neighbour's value. The pattern is now built segment by segment with proper escaping, and a malformed requirement returns "no match" instead of crashing the CLI.

**4. `router:debug` rendered a junk row.**

`.aplos/cache/router.js` holds page routes *and* the raw route-config entries from `aplos.config.js`, which carry `source`/`paths` but no component or path. Those were listed as a row with an empty Component and Path, padded with the table's own `-` and `Any` placeholders. The match branch already guarded this; the listing branch now does too.

## Behaviour change

`router:match` and `router:debug <component>` now exit **1** when nothing matches, instead of always exiting 0. A failed lookup was previously indistinguishable from a hit, which made both commands unusable in a script. This is a deliberate break, pre-1.0.

## Tests

| Area | Tests | Approach |
|---|---|---|
| `MiddlewareGate` | 10 | happy-dom + real timers |
| `matchRoute` | 17 | pure |
| `router:*` commands | 6 | real CLI subprocess |
| Nested layouts | 4 | `buildRouter` over temp fixtures |
| SSG head injection | 13 | pure |

`happy-dom` is added as a devDependency and registered per-file in `tests/runtime/`, not through a global preload, so the build tests keep running in a plain Node-like environment.

Every test was mutation-checked: each fix was reverted in place to confirm the suite turns red. That caught two of my own tests asserting nothing useful — one passed with or without the guard it claimed to cover, another asserted "some cell is non-empty" when the junk row's placeholders are themselves non-empty. Both were rewritten until they discriminated. One case is documented in the test file as *not* pinned (the `cancelled` guard inside the microtask) rather than left looking covered, because proving it would require mocking `react-router-dom` wholesale, which breaks the other tests in that file.

## Coverage

- 89 → 139 tests, all green, lint clean
- `src/runtime/MiddlewareGate.jsx`: 0% → 98.73% lines, 100% functions
- `src/build/router.js`: 85.86% → 90.75% lines, 100% functions
- `src/command/router.js` and `src/build/config.js` now appear in the report at all; they were previously absent because no test loaded them, so the global percentage moves against a larger denominator.

## Note

One thing left alone, worth a follow-up: `tests/fixtures/basic` pins its peers with floating ranges (`react: ^19.0.0`), so the fixture can install a react version that skews against the react-dom resolved from the framework tree. That produced a React error #527 and a blank app during this work; it is one upstream release away from a confusing red CI. Left as-is because pinning is a judgement call: it also stops the fixture from catching a genuine upstream regression.
