### PR TITLE
Add server.strictPort, and fix APLOS_SERVER_PORT being ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Each entry references its pull request (`#NN`) when there is one, or the short
 commit hash otherwise. Full release notes live on the
 [releases page](https://github.com/alpac0de/aplos/releases).
 
+## [Unreleased]
+
+### Added
+
+- Add `server.strictPort` to fail on a busy port instead of falling back
+
+### Changed
+
+- `APLOS_SERVER_PORT` no longer decides the fallback policy, only the port value
+
+### Fixed
+
+- `APLOS_SERVER_PORT` was ignored whenever a project set `server.port`
+- #42 Fix a middleware redirect being dropped on cold load, leaving a blank page
+- #42 Fix nested `_layout` files never reaching the route tree
+- #42 Fix `router:match` reporting no match for every catch-all route
+- #42 Drop the junk row from `router:debug`, and exit non-zero when nothing matches
+
 ## [0.16.0] - 2026-07-14
 
 ### Added

--- a/aplos.config.dist.js
+++ b/aplos.config.dist.js
@@ -5,6 +5,12 @@ export default {
     // Server configuration
     server: {
         port: 3001,
+        // false (default): a busy port falls back to the next free one.
+        // true: fail instead. Use this when something outside the dev server has
+        // memorised the port (a reverse proxy registration, a docker port
+        // mapping, an OAuth redirect URI), where falling back would silently
+        // point that other side at nothing.
+        strictPort: false,
     },
     
     // Client-side runtime configuration

--- a/documentation/configuration/overview.md
+++ b/documentation/configuration/overview.md
@@ -108,6 +108,40 @@ Or using environment variable:
 APLOS_SERVER_PORT=4000 npx aplos server
 ```
 
+### Busy ports
+
+By default a busy port falls back to the next free one, and the dev server prints
+which port it settled on:
+
+```
+⚠ Port 3000 is in use, using port 3001 instead.
+```
+
+Set `strictPort` when the port is a constraint rather than a preference:
+
+```javascript
+module.exports = {
+  server: {
+    port: 3000,
+    strictPort: true
+  }
+}
+```
+
+Aplos then fails instead of falling back:
+
+```
+✗ Port 3000 is already in use.
+```
+
+Use this whenever something outside the dev server has memorised the port: a
+reverse proxy registration, a docker port mapping, an OAuth redirect URI. Falling
+back in those cases points the other side at nothing.
+
+`strictPort` is a policy, and `APLOS_SERVER_PORT` only carries a value: setting
+the environment variable changes which port is used, never whether Aplos falls
+back.
+
 ## Head Configuration
 
 The `head` option sets default meta tags, title, and links injected into every page.

--- a/src/build/config.js
+++ b/src/build/config.js
@@ -13,10 +13,16 @@ export default async () => {
         console.error(err);
     }
 
+    const defaultServer = {
+        port: 3000,
+        // Whether `port` is a constraint or a preference. False lets a busy port
+        // fall back to the next free one; true fails instead. See the rationale
+        // in src/command/devServer.js.
+        strictPort: false,
+    };
+
     let aplos = {
-        server: {
-            port: process.env.APLOS_SERVER_PORT || 3000,
-        },
+        server: {...defaultServer},
         routes: [],
         head: {
             defaultTitle: '',
@@ -33,8 +39,29 @@ export default async () => {
             const configModule = await import(pathToFileURL(configPath).href);
             const config = configModule.default || configModule;
             aplos = {...aplos, ...config};
+            // `server` is merged one level deeper than the rest. The spread above
+            // replaces the whole object, so a project declaring `server: { port }`
+            // used to drop every other server default. That is how APLOS_SERVER_PORT
+            // came to be ignored whenever a project set a port: the env var was
+            // baked into the default `server`, which the project's own block then
+            // replaced wholesale.
+            aplos.server = {...defaultServer, ...(config.server || {})};
         } catch (error) {
             console.error('Error loading configuration:', error);
+        }
+    }
+
+    // Applied after the config file so it wins over `server.port`, which is what
+    // an explicit env var is for: overriding the committed value for one run.
+    // Read here rather than as a default so it cannot be silently replaced.
+    if (process.env.APLOS_SERVER_PORT) {
+        const port = Number(process.env.APLOS_SERVER_PORT);
+        if (Number.isInteger(port) && port >= 0 && port <= 65535) {
+            aplos.server.port = port;
+        } else {
+            console.warn(
+                `[aplos] ignoring APLOS_SERVER_PORT="${process.env.APLOS_SERVER_PORT}": not a valid port.`,
+            );
         }
     }
 

--- a/src/command/devServer.js
+++ b/src/command/devServer.js
@@ -150,23 +150,54 @@ export default async () => {
         }
     });
 
-    // Determine port logic based on environment variable
-    let finalPort = config.server.port;
-    const isPortExplicitlySet = process.env.APLOS_SERVER_PORT;
-    
-    // If no explicit port set, find available port
-    if (!isPortExplicitlySet) {
+    // A busy port falls back to the next free one, unless `strictPort` says the
+    // port is a constraint rather than a preference.
+    //
+    // The policy used to hinge on WHICH CHANNEL carried the port: setting
+    // APLOS_SERVER_PORT refused to fall back, while `server.port` in
+    // aplos.config.js silently moved to another port. Both express the same
+    // intent, so the channel no longer decides. An explicit `strictPort` does,
+    // the way Vite models it. The env var still wins over the config file for the
+    // port VALUE; it just no longer changes the policy.
+    //
+    // Strict matters when something outside the dev server has memorised the
+    // port: a reverse-proxy registration, a docker port mapping, an OAuth
+    // redirect URI. Falling back there points the other side at nothing.
+    const configuredPort = config.server.port;
+    const strictPort = config.server.strictPort === true;
+
+    let finalPort = configuredPort;
+
+    if (strictPort) {
+        // Checked here rather than left to the dev server. RspackDevServer
+        // rethrows the listen error from an event handler, which no `.catch()` on
+        // start() can intercept, so the user gets a raw EADDRINUSE stack trace
+        // instead of a message naming the cause. Probing first keeps the failure
+        // legible.
+        if (!(await isPortAvailable(configuredPort))) {
+            console.error(`\x1b[31m✗ Port ${configuredPort} is already in use.\x1b[0m`);
+            console.error(
+                `\x1b[2m  server.strictPort is set, so Aplos will not fall back to another port.\x1b[0m`
+            );
+            process.exit(1);
+        }
+    } else {
         try {
-            finalPort = await findAvailablePort(config.server.port);
-            if (finalPort !== config.server.port) {
-                console.log(`Port ${config.server.port} is busy, using port ${finalPort}`);
+            finalPort = await findAvailablePort(configuredPort);
+            if (finalPort !== configuredPort) {
+                console.log(
+                    `\x1b[33m⚠ Port ${configuredPort} is in use, using port ${finalPort} instead.\x1b[0m`
+                );
+                console.log(
+                    `\x1b[2m  Set server.strictPort to fail instead of falling back.\x1b[0m`
+                );
             }
         } catch (error) {
             console.error(`Could not find available port: ${error.message}`);
             process.exit(1);
         }
     }
-    
+
     const devServerOptions = {
         hot: true,
         open: false,
@@ -191,8 +222,16 @@ export default async () => {
     };
 
     runServer().catch((error) => {
-        if (isPortExplicitlySet && error.code === 'EADDRINUSE') {
-            console.error(`Port ${finalPort} is already in use. Since APLOS_SERVER_PORT is set, refusing to use alternative port.`);
+        if (error.code === 'EADDRINUSE') {
+            // Only reachable under strictPort: the fallback path above already
+            // proved the port free otherwise (a race is still possible, and lands
+            // here with the same message, which is accurate either way).
+            console.error(
+                `\x1b[31m✗ Port ${finalPort} is already in use.\x1b[0m`
+            );
+            console.error(
+                `\x1b[2m  server.strictPort is set, so Aplos will not fall back to another port.\x1b[0m`
+            );
         } else {
             console.error(error);
         }

--- a/tests/build/server-config.test.js
+++ b/tests/build/server-config.test.js
@@ -1,0 +1,172 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import getConfig from '../../src/build/config.js';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const dirs = [];
+
+// Each case gets its own directory: `aplos.config.js` is loaded with a dynamic
+// import, and both Node and Bun cache that by resolved path. Reusing one
+// directory would silently serve the first test's config to every later one.
+async function withConfig(source, env, fn) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aplos-server-cfg-'));
+    dirs.push(dir);
+    if (source !== null) {
+        await fs.writeFile(path.join(dir, 'aplos.config.js'), source, 'utf-8');
+    }
+
+    const originalCwd = process.cwd;
+    const originalEnv = process.env.APLOS_SERVER_PORT;
+    process.cwd = () => dir;
+    if (env === undefined) {
+        delete process.env.APLOS_SERVER_PORT;
+    } else {
+        process.env.APLOS_SERVER_PORT = env;
+    }
+
+    try {
+        return await fn();
+    } finally {
+        process.cwd = originalCwd;
+        if (originalEnv === undefined) {
+            delete process.env.APLOS_SERVER_PORT;
+        } else {
+            process.env.APLOS_SERVER_PORT = originalEnv;
+        }
+    }
+}
+
+afterEach(async () => {
+    while (dirs.length) {
+        await fs.rm(dirs.pop(), { recursive: true, force: true });
+    }
+});
+
+describe('server config defaults', () => {
+    test('a project with no server block gets the defaults', async () => {
+        const config = await withConfig('export default {};', undefined, getConfig);
+
+        expect(config.server.port).toBe(3000);
+        expect(config.server.strictPort).toBe(false);
+    });
+
+    test('a project port overrides the default', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001 } };',
+            undefined,
+            getConfig,
+        );
+
+        expect(config.server.port).toBe(3001);
+    });
+
+    // The spread that merges the project config replaces `server` wholesale, so
+    // declaring only `port` used to drop every other server default with it.
+    test('declaring only port keeps the other server defaults', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001 } };',
+            undefined,
+            getConfig,
+        );
+
+        expect(config.server.strictPort).toBe(false);
+    });
+});
+
+describe('APLOS_SERVER_PORT', () => {
+    // The env var used to be baked into the default `server` object, which a
+    // project's own `server: { port }` then replaced: setting the variable had no
+    // effect at all on any project that configured a port.
+    test('wins over a port set in aplos.config.js', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001 } };',
+            '9999',
+            getConfig,
+        );
+
+        expect(config.server.port).toBe(9999);
+    });
+
+    test('applies when the project sets no port', async () => {
+        const config = await withConfig('export default {};', '9999', getConfig);
+
+        expect(config.server.port).toBe(9999);
+    });
+
+    test('is coerced to a number, not left as a string', async () => {
+        const config = await withConfig('export default {};', '9999', getConfig);
+
+        expect(config.server.port).toBe(9999);
+        expect(typeof config.server.port).toBe('number');
+    });
+
+    // A non-numeric value used to reach the dev server as NaN.
+    test('a non-numeric value is ignored, keeping the configured port', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001 } };',
+            'abcd',
+            getConfig,
+        );
+
+        expect(config.server.port).toBe(3001);
+    });
+
+    test('an out-of-range value is ignored', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001 } };',
+            '70000',
+            getConfig,
+        );
+
+        expect(config.server.port).toBe(3001);
+    });
+
+    test('an empty value is ignored', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001 } };',
+            '',
+            getConfig,
+        );
+
+        expect(config.server.port).toBe(3001);
+    });
+});
+
+describe('strictPort', () => {
+    test('defaults to false', async () => {
+        const config = await withConfig('export default {};', undefined, getConfig);
+
+        expect(config.server.strictPort).toBe(false);
+    });
+
+    test('is read from the project config', async () => {
+        const config = await withConfig(
+            'export default { server: { port: 3001, strictPort: true } };',
+            undefined,
+            getConfig,
+        );
+
+        expect(config.server.strictPort).toBe(true);
+    });
+
+    // The policy used to hinge on whether APLOS_SERVER_PORT was set at all.
+    // It must now depend on strictPort alone: the env var carries the port
+    // VALUE, never the fallback policy.
+    test('the env var does not change the policy', async () => {
+        const strict = await withConfig(
+            'export default { server: { strictPort: true } };',
+            '9999',
+            getConfig,
+        );
+        expect(strict.server.strictPort).toBe(true);
+        expect(strict.server.port).toBe(9999);
+
+        const loose = await withConfig(
+            'export default { server: { port: 3001 } };',
+            '9999',
+            getConfig,
+        );
+        expect(loose.server.strictPort).toBe(false);
+    });
+});

--- a/tests/command/dev-server-port.test.js
+++ b/tests/command/dev-server-port.test.js
@@ -1,0 +1,141 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { spawn } from 'node:child_process';
+import net from 'node:net';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const frameworkDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const ANSI_PATTERN = new RegExp(String.fromCharCode(27) + String.raw`\[[0-9;]*m`, 'g');
+
+const cleanups = [];
+
+/** Holds a port open so the dev server has to react to it being taken. */
+function occupyPort(port) {
+    return new Promise((resolve, reject) => {
+        const server = net.createServer();
+        server.once('error', reject);
+        server.listen(port, () => {
+            cleanups.push(() => new Promise((done) => server.close(done)));
+            resolve(server);
+        });
+    });
+}
+
+/** A port nothing is listening on, so the "free port" cases are not flaky. */
+function findFreePort() {
+    return new Promise((resolve, reject) => {
+        const probe = net.createServer();
+        probe.once('error', reject);
+        probe.listen(0, () => {
+            const { port } = probe.address();
+            probe.close(() => resolve(port));
+        });
+    });
+}
+
+async function scaffold(configSource) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aplos-devport-'));
+    cleanups.push(() => fs.rm(dir, { recursive: true, force: true }));
+
+    await fs.mkdir(path.join(dir, 'src', 'pages'), { recursive: true });
+    await fs.writeFile(path.join(dir, 'src', 'pages', 'index.jsx'), 'export default () => null');
+    await fs.writeFile(path.join(dir, 'aplos.config.js'), configSource, 'utf-8');
+
+    return dir;
+}
+
+/**
+ * Starts `aplos server` and resolves once it has either reported its port or
+ * exited. The dev server never exits on its own, so the success path is
+ * detected from the startup banner and the process is then killed.
+ */
+function runDevServer(cwd, { timeout = 25_000 } = {}) {
+    return new Promise((resolve) => {
+        const child = spawn(process.execPath, [path.join(frameworkDir, 'bin', 'aplos'), 'server'], {
+            cwd,
+            env: { ...process.env, FORCE_COLOR: '0' },
+        });
+
+        let output = '';
+        let settled = false;
+
+        const finish = (code) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            try { child.kill('SIGKILL'); } catch { /* already gone */ }
+            resolve({ code, output: output.replace(ANSI_PATTERN, '') });
+        };
+
+        const onData = (chunk) => {
+            output += chunk;
+            // The banner is the last thing printed on a successful start.
+            if (/Local:\s+http/.test(output)) finish(0);
+        };
+
+        child.stdout.on('data', onData);
+        child.stderr.on('data', onData);
+        child.on('close', (code) => finish(code));
+
+        const timer = setTimeout(() => finish(null), timeout);
+    });
+}
+
+afterEach(async () => {
+    while (cleanups.length) {
+        await cleanups.pop()();
+    }
+});
+
+// The fallback policy used to depend on WHICH CHANNEL carried the port: setting
+// APLOS_SERVER_PORT refused to fall back, while `server.port` in aplos.config.js
+// silently moved. Both express the same intent, so an explicit `strictPort` now
+// decides, and the channel no longer does.
+describe('dev server port selection', () => {
+    test('falls back to the next port when the configured one is busy', async () => {
+        const port = await findFreePort();
+        await occupyPort(port);
+        const dir = await scaffold(`export default { server: { port: ${port} } };`);
+
+        const { output } = await runDevServer(dir);
+
+        expect(output).toContain(`Port ${port} is in use`);
+        expect(output).toContain(`using port ${port + 1}`);
+        expect(output).toContain(`http://localhost:${port + 1}/`);
+        // The notice tells the user how to opt out of falling back.
+        expect(output).toContain('strictPort');
+    }, 40_000);
+
+    test('uses the configured port when it is free', async () => {
+        const port = await findFreePort();
+        const dir = await scaffold(`export default { server: { port: ${port} } };`);
+
+        const { output } = await runDevServer(dir);
+
+        expect(output).toContain(`http://localhost:${port}/`);
+        expect(output).not.toContain('is in use');
+    }, 40_000);
+});
+
+describe('strictPort', () => {
+    // RspackDevServer rethrows its listen error from an event handler, which no
+    // .catch() on start() can intercept: without an up-front probe the user gets
+    // a raw EADDRINUSE stack trace instead of a message naming the cause.
+    test('fails with a legible message when the port is busy', async () => {
+        const port = await findFreePort();
+        await occupyPort(port);
+        const dir = await scaffold(
+            `export default { server: { port: ${port}, strictPort: true } };`,
+        );
+
+        const { code, output } = await runDevServer(dir);
+
+        expect(code).toBe(1);
+        expect(output).toContain(`Port ${port} is already in use`);
+        expect(output).toContain('strictPort');
+        // The raw stack trace must not be what the user sees.
+        expect(output).not.toContain('EADDRINUSE');
+    }, 40_000);
+});


### PR DESCRIPTION
Adds `server.strictPort`, and fixes the port resolution it exposed.

## The problem

The fallback policy hinged on **which channel** carried the port, not on whether the user meant it as a constraint:

```js
server: { port: 3001 }   // busy → silently moves to 3002
APLOS_SERVER_PORT=3001   // busy → fails
```

Both express the same intent. Nothing documented the difference.

Worse, the two interacted badly. The env var was baked into the default `server` object, and the project's own `server` block replaced that object wholesale, so **`APLOS_SERVER_PORT` was ignored entirely whenever a project set `server.port`**. `lugha/client` works around this by hand, writing `port: process.env.APLOS_SERVER_PORT || 3003` in its own config.

## What changed

`strictPort` decides the policy; the channel no longer does. `APLOS_SERVER_PORT` still wins over the config file for the port *value*, it just no longer changes whether Aplos falls back.

```js
server: {
  port: 3000,
  strictPort: false,   // default: fall back and say so
}
```

Fallback now prints a visible notice pointing at the opt-out:

```
⚠ Port 3000 is in use, using port 3001 instead.
  Set server.strictPort to fail instead of falling back.
```

Strict fails with a legible message:

```
✗ Port 3000 is already in use.
  server.strictPort is set, so Aplos will not fall back to another port.
```

The strict check probes the port **before** starting the dev server. `RspackDevServer` rethrows its listen error from an event handler, which no `.catch()` on `start()` can intercept, so without the probe the user gets a raw `EADDRINUSE` stack trace instead of a message naming the cause. A test asserts the stack trace is not what they see.

Also fixed along the way: `APLOS_SERVER_PORT` is now validated. `abcd` used to reach the dev server as `NaN`; it is now ignored with a warning, as is an out-of-range value.

## Why this shape

Two designs exist in the wild, and I checked both in source rather than from memory:

| Framework | Default when busy | Strict option | Channel decides? |
|---|---|---|---|
| Vite | falls back (`port++`) | `server.strictPort` | no |
| Next.js | **depends on channel** (`allowRetry = portSource === 'default'`) | none, implicit | **yes** |
| Astro | falls back (via Vite) | via Vite's | no |
| webpack-dev-server | **fails** | inverted: `port: 'auto'` to fall back | no |
| Nuxt | falls back, then **random port** | `random: false` in prod | partly |

Aplos was accidentally in the Next.js camp. Vite's model is the better fit here: it is explicit, it does not surprise, and it lets a project pin a port regardless of how it is passed. That matters when something outside the dev server has memorised the port, which is exactly the reverse-proxy registration case (`lugha/client` registers its dev server with Sozune).

Next's model also has a quirk worth avoiding: `next dev -p 3000` fails while a bare `next dev` (which also targets 3000) falls back. Asking for the default value explicitly changes the behaviour.

## Behaviour change

A project that relied on `APLOS_SERVER_PORT` refusing to fall back now needs `strictPort: true`. Pre-1.0, and the previous behaviour was undocumented and inconsistent with `server.port`.

Projects that work around the merge bug by writing `port: process.env.APLOS_SERVER_PORT || 3003` keep working; that line is now redundant and can be dropped.

## Tests

- 12 unit tests on config resolution (defaults, precedence, validation, the shallow-merge fix)
- 3 integration tests driving the real CLI: fallback, strict failure, free port

139 → 154 tests, all green, lint clean.

Both fixes were mutation-checked: reverting the shallow merge turns 2 tests red, reverting the env-var precedence turns 4 red, and ignoring `strictPort` turns the strict test red.

The dev server tests spawn a real build, so they cost ~50s. That is most of the suite's wall time; I traded two extra assertions into existing cases rather than starting more servers.
