### PR TITLE
Return the built routes from buildRouter instead of re-parsing the cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 # framework out, not the committed fixtures the build tests run against.
 /src/pages
 /aplos.config.js
+.gstack/

--- a/src/build/router.js
+++ b/src/build/router.js
@@ -258,6 +258,34 @@ export async function buildRouter(aplos) {
         console.error('Failed to write cache files:', error.message);
         throw error;
     }
+
+    // The routes this build produced, as data.
+    //
+    // Everything callers know about routes today, they know by reading the
+    // generated files back off disk and parsing them: `router:debug` does it in
+    // src/command/router.js, and the SSG rediscovers static routes through the
+    // SSR bundle. Both are re-derivations of something this function already
+    // held in memory and threw away.
+    //
+    // A copy, not the live array: `pages` entries are mutated while the tree is
+    // assembled, and handing out a reference would make that shape permanent.
+    // Only the fields a consumer can act on are exposed, so the internal record
+    // stays free to change.
+    return {
+        routes: pages.map((page) => ({
+            path: page.path,
+            component: page.component,
+            file: page.file,
+            static: page.static === true,
+            // Per-parameter regex constraints, as declared in aplos.config.js.
+            // `router:match` needs these to answer honestly: without them a URL
+            // matches a route whose requirements it actually fails.
+            requirements: page.requirements || page.requirement || {},
+            // Set only on routes expanded from a catch-all's `paths`; it names
+            // the source pattern they were rendered through.
+            sourcePath: page.sourcePath ?? null,
+        })),
+    };
 }
 
 /**

--- a/src/command/router.js
+++ b/src/command/router.js
@@ -1,7 +1,6 @@
 import { buildRouter } from "../build/router.js";
 import get_config from "../build/config.js";
 import Table from "cli-table3";
-import fs from "fs";
 
 
 /**
@@ -100,12 +99,11 @@ function neutralizeGroups(requirement) {
 export default async (options) => {
   let projectDirectory = process.cwd();
 
-  await buildRouter(await get_config(projectDirectory));
-
-  const data = fs
-    .readFileSync(projectDirectory + "/.aplos/cache/router.js")
-    .toString();
-  const routes = JSON.parse(data);
+  // Read from what the build returned rather than writing the cache, reading it
+  // back and parsing it. The round trip through disk was also what surfaced the
+  // raw aplos.config.js route entries (no component, no path) that used to
+  // render as a junk row: the returned result only contains real routes.
+  const { routes } = await buildRouter(await get_config(projectDirectory));
 
   // Handle router:match command
   if (options && options.url) {
@@ -186,7 +184,8 @@ export default async (options) => {
 
       table.push(["Scheme", ""]);
 
-      table.push(["Requirement", route.requirement]);
+      const reqs = route.requirements || {};
+      table.push(["Requirements", Object.keys(reqs).length > 0 ? JSON.stringify(reqs) : "NO CUSTOM"]);
 
       console.log(table.toString());
     } else {
@@ -198,10 +197,10 @@ export default async (options) => {
       head: ["Component", "File", "Scheme", "Host", "Path"],
     });
 
-    // `.aplos/cache/router.js` holds the page routes AND the raw route-config
-    // entries from aplos.config.js, which carry `source`/`paths` but no
-    // component or path. Listing those rendered a fully blank table row. The
-    // match branch above already guards this the same way.
+    // The guard is redundant now that the routes come from buildRouter's return
+    // value rather than the cache file (which also held raw aplos.config.js
+    // entries with no component or path, and rendered them as a blank row). Kept
+    // as a cheap invariant: nothing here should ever render a pathless row.
     routes
       .filter((route) => route.path)
       .forEach((route) => {

--- a/tests/build/router-result.test.js
+++ b/tests/build/router-result.test.js
@@ -1,0 +1,136 @@
+import { describe, test, expect, afterEach } from 'bun:test';
+import { buildRouter } from '../../src/build/router.js';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+const dirs = [];
+
+const PAGE = 'export default () => null';
+const STATIC_PAGE = '"use static"\nexport default () => null';
+
+async function scaffold(files) {
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'aplos-router-result-'));
+    dirs.push(dir);
+
+    for (const [file, contents] of Object.entries(files)) {
+        const target = path.join(dir, 'src', 'pages', file);
+        await fs.mkdir(path.dirname(target), { recursive: true });
+        await fs.writeFile(target, contents, 'utf-8');
+    }
+
+    return dir;
+}
+
+async function build(dir, config = { routes: [] }) {
+    const original = process.cwd;
+    process.cwd = () => dir;
+    try {
+        return await buildRouter(config);
+    } finally {
+        process.cwd = original;
+    }
+}
+
+afterEach(async () => {
+    while (dirs.length) {
+        await fs.rm(dirs.pop(), { recursive: true, force: true });
+    }
+});
+
+// Everything a caller knows about routes today, it knows by reading the
+// generated cache files back off disk and parsing them. `buildRouter` held that
+// information in memory and dropped it. Returning it is what lets a consumer
+// (a sitemap generator, `router:debug`) work from data instead of re-deriving.
+describe('buildRouter returns the routes it produced', () => {
+    test('returns one entry per page', async () => {
+        const dir = await scaffold({ 'index.jsx': PAGE, 'about.jsx': PAGE });
+
+        const { routes } = await build(dir);
+
+        expect(routes.map((r) => r.path).sort()).toEqual(['/', '/about']);
+    });
+
+    test('each entry carries its component and source file', async () => {
+        const dir = await scaffold({ 'index.jsx': PAGE });
+
+        const { routes } = await build(dir);
+
+        expect(routes[0].component).toBe('Index');
+        expect(routes[0].file).toBe('/index.jsx');
+    });
+
+    test('a "use static" page is reported as static', async () => {
+        const dir = await scaffold({ 'index.jsx': PAGE, 'about.jsx': STATIC_PAGE });
+
+        const { routes } = await build(dir);
+
+        const byPath = Object.fromEntries(routes.map((r) => [r.path, r]));
+        expect(byPath['/about'].static).toBe(true);
+        expect(byPath['/'].static).toBe(false);
+    });
+
+    test('static is always a boolean, never undefined', async () => {
+        const dir = await scaffold({ 'index.jsx': PAGE });
+
+        const { routes } = await build(dir);
+
+        expect(typeof routes[0].static).toBe('boolean');
+    });
+
+    // A sitemap needs the concrete URLs, not the catch-all pattern they came
+    // from, and it needs to tell the two apart.
+    test('routes expanded from a catch-all name the source they came from', async () => {
+        const dir = await scaffold({
+            'index.jsx': PAGE,
+            'blog/[...slug].jsx': PAGE,
+        });
+
+        const { routes } = await build(dir, {
+            routes: [{ source: '/blog/[...slug]', paths: ['/blog/a', '/blog/b'] }],
+        });
+
+        const expanded = routes.filter((r) => r.sourcePath !== null);
+        expect(expanded.map((r) => r.path).sort()).toEqual(['/blog/a', '/blog/b']);
+        expect(expanded.every((r) => r.sourcePath === '/blog/[...slug]')).toBe(true);
+        // They are pre-rendered, so a sitemap should list them.
+        expect(expanded.every((r) => r.static)).toBe(true);
+    });
+
+    test('a page declared on disk has no sourcePath', async () => {
+        const dir = await scaffold({ 'index.jsx': PAGE });
+
+        const { routes } = await build(dir);
+
+        expect(routes[0].sourcePath).toBeNull();
+    });
+
+    test('expanded routes reuse the catch-all component', async () => {
+        const dir = await scaffold({
+            'index.jsx': PAGE,
+            'blog/[...slug].jsx': PAGE,
+        });
+
+        const { routes } = await build(dir, {
+            routes: [{ source: '/blog/[...slug]', paths: ['/blog/a'] }],
+        });
+
+        const expanded = routes.find((r) => r.path === '/blog/a');
+        const catchAll = routes.find((r) => r.path === '/blog/*');
+        expect(expanded.component).toBe(catchAll.component);
+    });
+
+    // The returned records must not be the live objects the tree builder mutates,
+    // or their internal shape becomes part of the contract.
+    test('mutating the result does not corrupt a later build', async () => {
+        const dir = await scaffold({ 'index.jsx': PAGE });
+
+        const first = await build(dir);
+        first.routes[0].path = '/mutated';
+        first.routes.push({ path: '/injected' });
+
+        const second = await build(dir);
+
+        expect(second.routes.map((r) => r.path)).toEqual(['/']);
+    });
+});

--- a/tests/command/router-cli.test.js
+++ b/tests/command/router-cli.test.js
@@ -81,11 +81,20 @@ describe('aplos router:debug', () => {
             // Drop the header row.
             .filter((cells) => cells[0] !== 'Component');
 
-        expect(rows.length).toBe(2);
+        // index, the catch-all, and the concrete `/blog/a` expanded from its
+        // `paths`. That third row is real: it is a route the SSG pre-renders,
+        // and listing it is the point of the command.
+        expect(rows.length).toBe(3);
         for (const [component, , , , routePath] of rows) {
             expect(component).not.toBe('');
             expect(routePath).not.toBe('');
         }
+    });
+
+    test('lists routes expanded from a catch-all\'s paths', async () => {
+        const { stdout } = await runCli(project, ['router:debug']);
+
+        expect(stdout).toContain('/blog/a');
     });
 
     test('exits non-zero when the component does not exist', async () => {


### PR DESCRIPTION
`buildRouter` held the full route list in memory and returned nothing. Every caller that needed to know what routes exist re-derived them: `router:debug` and `router:match` wrote the cache to disk, read it back, and `JSON.parse`d it.

That round trip is also where the junk row came from. `.aplos/cache/router.js` holds page routes *and* the raw `aplos.config.js` route-config entries, which carry `source`/`paths` but no component or path. Reading the file back meant reading those too.

## What changed

`buildRouter` now returns the routes it produced:

```js
const { routes } = await buildRouter(config);
// [{ path, component, file, static, requirements, sourcePath }]
```

`sourcePath` is set only on routes expanded from a catch-all's `paths`, naming the pattern they were rendered through. `static` is always a boolean.

The records are a copy, not the live `pages` array: entries are mutated while the route tree is assembled, and handing out a reference would freeze that internal shape into the contract. Only the fields a consumer can act on are exposed.

`src/command/router.js` reads that result instead of the cache file. The write/read/parse round trip is gone, along with the `fs` import.

## Visible improvement

`router:debug` now lists routes expanded from a catch-all's `paths`, which the cache round trip could not distinguish from config noise:

```
│ BlogSlug  │ src/pages/blog/[...slug].jsx │ Any │ Any │ /blog/* │
│ BlogSlug  │ src/pages/blog/[...slug].jsx │ Any │ Any │ /blog/a │   <- new
```

`/blog/a` is a route the SSG actually pre-renders. Listing it is the point of the command.

`router:debug <component>` also had a latent bug: it read `route.requirement` (singular) while the config field is `requirements`, so the row rendered `undefined`. It now prints the requirements or `NO CUSTOM`, matching what `router:match` already did.

## Why

Groundwork for the plugin API. A `buildEnd` hook that hands a sitemap generator its routes needs those routes to exist as data, not as generated JavaScript that has to be parsed back. Right now `ring/website/scripts/generate-seo.js` re-walks the docs directory to rediscover routes the build already knew, which is the fifth copy of the same directory walker in this ecosystem.

This lands the data model on its own, ahead of any plugin contract, because it is useful without one: the CLI is already better for it.

## Tests

8 new tests on the returned shape: one entry per page, `static` correctness for both `"use static"` and `paths` expansion, `sourcePath` presence and absence, component reuse across expanded routes, and a defensive-copy test proving a caller cannot corrupt a later build by mutating the result.

157 → 163 tests, all green, lint clean.

Mutation-checked: returning the live `pages` array instead of a copy turns 2 tests red.

One existing test changed expectation from 2 rows to 3. That is the improvement above, not a regression: the third row is a real pre-rendered route that was previously invisible.
